### PR TITLE
スポットライト枠のUIを修正する

### DIFF
--- a/src/components/Form/MediaType.tsx
+++ b/src/components/Form/MediaType.tsx
@@ -1,11 +1,34 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { setMediaType, SoraDemoState } from "@/slice";
+import { setFakeVolume, setMediaType, SoraDemoState } from "@/slice";
 import { isMediaType } from "@/utils";
 
+const VolumeRange: React.FC = () => {
+  const fakeVolume = useSelector((state: SoraDemoState) => state.fakeVolume);
+  const dispatch = useDispatch();
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    dispatch(setFakeVolume(event.target.value));
+  };
+  return (
+    <div className="form-check ml-2">
+      <input
+        id="fakeVolume"
+        className="fake-volume-range"
+        type="range"
+        min="0"
+        max="1"
+        step="0.01"
+        value={fakeVolume}
+        onChange={onChange}
+      />
+    </div>
+  );
+};
+
 const GetDisplayMedia: React.FC = () => {
-  const { soraContents, mediaType } = useSelector((state: SoraDemoState) => state);
+  const soraContents = useSelector((state: SoraDemoState) => state.soraContents);
+  const mediaType = useSelector((state: SoraDemoState) => state.mediaType);
   const disabled = soraContents.sora !== null;
   const dispatch = useDispatch();
   const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -60,6 +83,7 @@ const GetDisplayMedia: React.FC = () => {
           fakeMedia
         </label>
       </div>
+      {mediaType === "fakeMedia" ? <VolumeRange /> : null}
     </div>
   );
 };

--- a/src/components/Video/LocalVideo.tsx
+++ b/src/components/Video/LocalVideo.tsx
@@ -42,7 +42,7 @@ const VideoBox: React.FC = () => {
   return (
     <>
       <div className="d-flex">
-        <div className={"d-flex flex-nowrap align-items-start" + (focused ? " spotlight-focused" : "")}>
+        <div className={"d-flex flex-nowrap align-items-start video-wrapper" + (focused ? " spotlight-focused" : "")}>
           <Video
             stream={localMediaStream}
             setHeight={setHeight}

--- a/src/components/Video/LocalVideo.tsx
+++ b/src/components/Video/LocalVideo.tsx
@@ -1,38 +1,15 @@
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
-import { setFakeVolume, SoraDemoState } from "@/slice";
+import { SoraDemoState } from "@/slice";
 import { ConnectType } from "@/utils";
 
 import ConnectionStatusBar from "./ConnectionStatusBar";
 import Video from "./Video";
 import VolumeVisualizer from "./VolumeVisualizer";
 
-const VolumeRange: React.FC = () => {
-  const { fakeVolume } = useSelector((state: SoraDemoState) => state);
-  const dispatch = useDispatch();
-  const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setFakeVolume(event.target.value));
-  };
-  return (
-    <div>
-      <input
-        id="fakeVolume"
-        className="fake-volume-range"
-        type="range"
-        min="0"
-        max="1"
-        step="0.01"
-        value={fakeVolume}
-        onChange={onChange}
-      />
-    </div>
-  );
-};
-
 const VideoBox: React.FC = () => {
   const [height, setHeight] = useState<number>(0);
-  const mediaType = useSelector((state: SoraDemoState) => state.mediaType);
   const audioOutput = useSelector((state: SoraDemoState) => state.audioOutput);
   const displayResolution = useSelector((state: SoraDemoState) => state.displayResolution);
   const focusedSpotlightConnectionIds = useSelector((state: SoraDemoState) => state.focusedSpotlightConnectionIds);
@@ -53,7 +30,6 @@ const VideoBox: React.FC = () => {
           {localMediaStream !== null ? <VolumeVisualizer stream={localMediaStream} height={height} /> : null}
         </div>
       </div>
-      {mediaType === "fakeMedia" ? <VolumeRange /> : null}
     </>
   );
 };

--- a/src/components/Video/RemoteVideos.tsx
+++ b/src/components/Video/RemoteVideos.tsx
@@ -132,7 +132,7 @@ const RemoteVideo: React.FC<RemoteVideoProps> = (props) => {
         </div>
       </div>
       <div className="d-flex flex-wrap align-items-start overflow-hidden">
-        <div className={"d-flex flex-nowrap align-items-start" + (focused ? " spotlight-focused" : "")}>
+        <div className={"d-flex flex-nowrap align-items-start video-wrapper" + (focused ? " spotlight-focused" : "")}>
           <Video
             stream={props.stream}
             setHeight={setHeight}

--- a/src/pages/_app.css
+++ b/src/pages/_app.css
@@ -178,8 +178,14 @@ footer .btn {
   margin-left: 0.25rem;
 }
 
+.video-wrapper {
+  border: 5px solid rgba(0, 0, 0, 0.1);
+  border-radius: 5px;
+}
+
 .spotlight-focused {
-  border: 5px solid var(--primary);
+  outline: 5px solid var(--primary);
+  outline-offset: -5px;
   border-radius: 5px;
 }
 

--- a/src/pages/_app.css
+++ b/src/pages/_app.css
@@ -184,8 +184,7 @@ footer .btn {
 }
 
 .spotlight-focused {
-  outline: 5px solid var(--primary);
-  outline-offset: -5px;
+  border: 5px solid var(--primary);
   border-radius: 5px;
 }
 


### PR DESCRIPTION
- 枠が出た場合に video box 全体のサイズが変わらないようにする
- fake media 用の volume meter を移動する