### PR TITLE
OPFS から localStorage フォールバックを削除する

### DIFF
--- a/src/opfs.ts
+++ b/src/opfs.ts
@@ -15,11 +15,10 @@ export type SignalingUrlCandidatesSettings = {
 };
 
 // OPFS から URL エントリを読み込む
-export async function loadUrlEntriesFromOPFS(): Promise<UrlEntry[]> {
+export async function loadUrlEntries(): Promise<UrlEntry[]> {
   try {
     // OPFS がサポートされているか確認
     if (!navigator.storage || !navigator.storage.getDirectory) {
-      console.warn("OPFS is not supported in this browser");
       return [];
     }
 
@@ -45,7 +44,6 @@ export async function saveUrlEntriesToOPFS(urlEntries: UrlEntry[]): Promise<void
   try {
     // OPFS がサポートされているか確認
     if (!navigator.storage || !navigator.storage.getDirectory) {
-      console.warn("OPFS is not supported in this browser");
       return;
     }
 
@@ -89,22 +87,10 @@ export async function saveUrlEntriesToOPFS(urlEntries: UrlEntry[]): Promise<void
       const writable = await newFileHandle.createWritable();
       await writable.write(content);
       await writable.close();
-    } else {
-      // Safari の古いバージョンでは OPFS への書き込みがメインスレッドからできない
-      // この場合は localStorage にフォールバック
-      localStorage.setItem("sora-devtools-signaling-url-candidates", content);
     }
-  } catch (error) {
-    console.error("Failed to save urlEntries to OPFS:", error);
-    // フォールバックとして localStorage に保存
-    try {
-      const settings: SignalingUrlCandidatesSettings = {
-        urlEntries,
-      };
-      localStorage.setItem("sora-devtools-signaling-url-candidates", JSON.stringify(settings));
-    } catch {
-      // localStorage も失敗した場合は諦める
-    }
+    // OPFS への書き込みがサポートされていない場合は何もしない
+  } catch {
+    // OPFS への保存に失敗した場合は何もしない
   }
 }
 
@@ -113,7 +99,6 @@ export async function purgeUrlEntriesFromOPFS(): Promise<void> {
   try {
     // OPFS がサポートされているか確認
     if (!navigator.storage || !navigator.storage.getDirectory) {
-      console.warn("OPFS is not supported in this browser");
       return;
     }
 
@@ -122,36 +107,4 @@ export async function purgeUrlEntriesFromOPFS(): Promise<void> {
   } catch {
     // ファイルが存在しない場合は無視
   }
-
-  // localStorage のフォールバックも削除
-  try {
-    localStorage.removeItem("sora-devtools-signaling-url-candidates");
-  } catch {
-    // 無視
-  }
-}
-
-// localStorage からのフォールバック読み込み
-export function loadUrlEntriesFromLocalStorage(): UrlEntry[] {
-  try {
-    const stored = localStorage.getItem("sora-devtools-signaling-url-candidates");
-    if (stored) {
-      const settings = JSON.parse(stored) as SignalingUrlCandidatesSettings;
-      if (Array.isArray(settings.urlEntries)) {
-        return settings.urlEntries;
-      }
-    }
-  } catch {
-    // パースエラーの場合は無視
-  }
-  return [];
-}
-
-// OPFS から読み込み、失敗した場合は localStorage から読み込む
-export async function loadUrlEntries(): Promise<UrlEntry[]> {
-  const fromOPFS = await loadUrlEntriesFromOPFS();
-  if (fromOPFS.length > 0) {
-    return fromOPFS;
-  }
-  return loadUrlEntriesFromLocalStorage();
 }


### PR DESCRIPTION
- localStorage はセキュリティ上のリスクがあるため削除
- OPFS 未サポート環境では設定が保存されない仕様に変更
- console.warn / console.error を削除してサイレントに処理