### PR TITLE
JsonTree の文字列値を折り返し表示にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
   - OffscreenCanvas を使用して Worker 内で描画
   - Chrome/Edge/Safari 対応（Firefox 非対応）
   - @voluntas
+- [CHANGE] デバッグパネルで長い文字列を折り返し表示にする
+  - @voluntas
 - [UPDATE] switch フォームのラベルクリックで switch を切り替え可能にする
   - @voluntas
 - [UPDATE] tooltip 付きフォームラベルのカーソルを `?` マークから通常カーソルに変更する

--- a/src/components/DebugPane/JsonTree.tsx
+++ b/src/components/DebugPane/JsonTree.tsx
@@ -118,7 +118,12 @@ export function JsonTree({ data, prevData, name, isLast = true, level = 0 }: Jso
           undefined
         </span>
       );
-    if (typeof value === "string") return <span style={highlightStyle}>"{value}"</span>;
+    if (typeof value === "string")
+      return (
+        <span className="break-all" style={highlightStyle}>
+          "{value}"
+        </span>
+      );
     if (typeof value === "number") return <span style={highlightStyle}>{value}</span>;
     if (typeof value === "boolean") return <span style={highlightStyle}>{value.toString()}</span>;
     // unknown 型の値を安全に文字列化

--- a/src/components/DebugPane/Message.tsx
+++ b/src/components/DebugPane/Message.tsx
@@ -20,12 +20,13 @@ function Description(props: DescriptionProps) {
   if (description === undefined) {
     return null;
   }
-  const wordBreakClass = props.wordBreak ? "whitespace-pre-wrap break-all" : "";
   if (typeof description !== "object") {
     return (
-      <div className="flex flex-nowrap text-white">
-        <div className="py-1 px-4 w-full">
-          <pre className={`text-base text-white m-0 ${wordBreakClass}`}>{description}</pre>
+      <div className="text-white">
+        <div className="py-1 px-4">
+          <pre className="text-base text-white m-0 whitespace-pre-wrap break-all">
+            {description}
+          </pre>
         </div>
       </div>
     );
@@ -33,20 +34,18 @@ function Description(props: DescriptionProps) {
   // prevDescription が渡されている場合は JsonTree を使用（差分更新あり）
   if (prevDescription !== undefined) {
     return (
-      <div className="flex flex-nowrap text-white">
-        <div className="py-1 px-4 w-full">
-          <div className={wordBreakClass}>
-            <JsonTree data={description} prevData={prevDescription} />
-          </div>
+      <div className="text-white">
+        <div className="py-1 px-4">
+          <JsonTree data={description} prevData={prevDescription} />
         </div>
       </div>
     );
   }
   // prevDescription がない場合は従来通り JSON.stringify
   return (
-    <div className="flex flex-nowrap text-white">
-      <div className="py-1 px-4 w-full">
-        <pre className={`text-base text-white m-0 ${wordBreakClass}`}>
+    <div className="text-white">
+      <div className="py-1 px-4">
+        <pre className="text-base text-white m-0 whitespace-pre-wrap break-all">
           {JSON.stringify(description, null, 2)}
         </pre>
       </div>


### PR DESCRIPTION
- 長い文字列値に break-all を適用して折り返し
- JSON 構造は維持しつつ長い値のみ折り返す
- Message の Description コンポーネントを簡略化