### PR TITLE
fakeMedia 利用時の AudioContext リソースリークを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,11 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] fakeMedia 利用時に AudioContext がリークしてハードウェアコンテキスト上限に達する問題を修正する
+  - createFakeMediaStream の戻り値に audioContext を追加し signal で保持する
+  - 解像度変更や再接続などで MediaStream を作り直す際に旧 AudioContext を close する
+  - disposeMedia / disconnect / resetState で確実に close する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0001-fix-audio-context-leak.md
+++ b/issues/closed/0001-fix-audio-context-leak.md
@@ -1,6 +1,7 @@
 # 0001 FakeMedia 生成時の AudioContext リソースリークを修正する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -123,3 +124,13 @@ fakeContents.value = { ...fakeContents.value, audioContext, gainNode };
 - `disposeMedia` 実行後に `fakeContents.value.audioContext` が null になっていること（close 後）
 - 上記テストは `vitest-browser-preact` の browser mode で実行する（`AudioContext` はブラウザ API のため Node.js では利用不可）
 - `fakeContents` の `audioContext` 型追加に伴う TypeScript コンパイルエラーがないこと
+
+## 解決方法
+
+- `src/types.ts` の `fakeContents` 型に `audioContext: AudioContext | null` を追加。
+- `src/utils.ts` の `createFakeMediaStream` の戻り値に `audioContext` を追加。
+- `src/app/signals.ts` で `setFakeContentsGainNode` を `setFakeContentsAudio(audioContext, gainNode)` に置き換え、close 専用の `closeFakeContentsAudio` を追加。`resetState` でも close する。
+- `src/app/actions.ts` で createMediaStream / createFakeMediaStreamFromState / createDisplayMediaStream / createUserMediaStream の戻り値タプルに `AudioContext | null` を追加。
+- `createFakeMediaStreamFromState` で `createFakeMediaStream` 呼び出し前に `closeFakeContentsAudio` で旧 AudioContext を close する。Chrome のハードウェアコンテキスト上限に達するのを防ぐため、新規生成前に close する必要がある。
+- `requestMedia` / `connectSora` / `reconnectSora` / `updateMediaStream` (mic/camera デバイスアクション) で `setFakeContentsAudio(audioContext, gainNode)` を使って signal を更新する。
+- `disposeMedia` および disconnect コールバックで `closeFakeContentsAudio` を呼び出して AudioContext を確実に close する。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -655,10 +655,10 @@ function applyTrackSettings(mediaStream: MediaStream, state: createMediaStreamPi
 // getDisplayMedia を使用して MediaStream を生成する
 async function createDisplayMediaStream(
   state: createMediaStreamPickedState,
-): Promise<[MediaStream, null]> {
+): Promise<[MediaStream, null, null]> {
   const LOG_TITLE = "MEDIA_CONSTRAINTS";
   if (!state.video || !state.cameraDevice) {
-    return [new MediaStream(), null];
+    return [new MediaStream(), null, null];
   }
   if (navigator.mediaDevices === undefined) {
     throw new Error("Failed to call getUserMedia. Make sure domain is secure");
@@ -695,17 +695,17 @@ async function createDisplayMediaStream(
     track.enabled = state.videoTrack;
     signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("start", track));
   }
-  return [stream, null];
+  return [stream, null, null];
 }
 
 // フェイクメディアを使用して MediaStream を生成する
 function createFakeMediaStreamFromState(
   state: createMediaStreamPickedState,
-): [MediaStream, GainNode | null] {
+): [MediaStream, GainNode | null, AudioContext | null] {
   const LOG_TITLE = "MEDIA_CONSTRAINTS";
   const { worker } = state.fakeContents;
   if (!worker) {
-    return [new MediaStream(), null];
+    return [new MediaStream(), null, null];
   }
   const constraints = createFakeMediaConstraints({
     audio: state.audio && state.micDevice,
@@ -721,7 +721,11 @@ function createFakeMediaStreamFromState(
     description: JSON.stringify(constraints),
   });
   signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("media-constraints", constraints));
-  const { offscreenCanvas, mediaStream, gainNode, frameRate } = createFakeMediaStream(constraints);
+  // Chrome のハードウェアコンテキスト上限に到達しないよう、新規生成前に旧 AudioContext を close する
+  // close は非同期だが Chrome は即座に上限から解放する
+  signals.closeFakeContentsAudio();
+  const { offscreenCanvas, mediaStream, gainNode, audioContext, frameRate } =
+    createFakeMediaStream(constraints);
   if (offscreenCanvas !== null) {
     // 現在の Worker を停止
     worker.postMessage({ type: "stop" });
@@ -747,13 +751,13 @@ function createFakeMediaStreamFromState(
     signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("start", track));
   }
   signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("succeed-create-fake-media"));
-  return [mediaStream, gainNode];
+  return [mediaStream, gainNode, audioContext];
 }
 
 // getUserMedia を使用して MediaStream を生成する
 async function createUserMediaStream(
   state: createMediaStreamPickedState,
-): Promise<[MediaStream, null]> {
+): Promise<[MediaStream, null, null]> {
   const LOG_TITLE = "MEDIA_CONSTRAINTS";
   if (navigator.mediaDevices === undefined) {
     throw new Error("Failed to call getUserMedia. Make sure domain is secure");
@@ -835,13 +839,13 @@ async function createUserMediaStream(
     }
   }
   applyTrackSettings(mediaStream, state);
-  return [mediaStream, null];
+  return [mediaStream, null, null];
 }
 
 // State に応じて MediaStream インスタンスを生成する
 async function createMediaStream(
   state: createMediaStreamPickedState,
-): Promise<[MediaStream, GainNode | null]> {
+): Promise<[MediaStream, GainNode | null, AudioContext | null]> {
   if (state.mediaType === "getDisplayMedia") {
     return createDisplayMediaStream(state);
   }
@@ -854,7 +858,7 @@ async function createMediaStream(
     }
     // 指定の MP4 を再生するための MediaStream を返す
     // DevTools ではいったん常に繰り返し再生にしておく
-    return [await state.mp4MediaStream.play({ repeat: true }), null];
+    return [await state.mp4MediaStream.play({ repeat: true }), null, null];
   }
   return createUserMediaStream(state);
 }
@@ -1008,6 +1012,8 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     if (fakeContentsValue.worker) {
       fakeContentsValue.worker.postMessage({ type: "stop" });
     }
+    // fakeMedia 利用時の AudioContext を close する
+    signals.closeFakeContentsAudio();
     signals.setSora(null);
     signals.setSoraSessionId(null);
     signals.setSoraConnectionId(null);
@@ -1160,8 +1166,9 @@ export const requestMedia = async (): Promise<void> => {
   const state = getStateForMediaStream();
   let mediaStream: undefined | MediaStream;
   let gainNode: undefined | GainNode | null;
+  let audioContext: undefined | AudioContext | null;
   try {
-    [mediaStream, gainNode] = await createMediaStream(state).catch((error) => {
+    [mediaStream, gainNode, audioContext] = await createMediaStream(state).catch((error) => {
       throw error;
     });
   } catch (error) {
@@ -1175,9 +1182,7 @@ export const requestMedia = async (): Promise<void> => {
     cleanupMediaStreamOnError(state, mediaStream);
     throw error;
   }
-  if (gainNode) {
-    signals.setFakeContentsGainNode(gainNode);
-  }
+  signals.setFakeContentsAudio(audioContext, gainNode);
   signals.setLocalMediaStream(mediaStream);
 };
 
@@ -1221,6 +1226,8 @@ export const disposeMedia = async (): Promise<void> => {
   if (fakeContentsValue.worker) {
     fakeContentsValue.worker.postMessage({ type: "stop" });
   }
+  // fakeMedia 利用時の AudioContext を close する
+  signals.closeFakeContentsAudio();
   signals.setLocalMediaStream(null);
 };
 
@@ -1340,6 +1347,7 @@ export const connectSora = async (): Promise<void> => {
   let soraConnection: undefined | ConnectionPublisher | ConnectionSubscriber;
   let mediaStream: undefined | MediaStream;
   let gainNode: undefined | GainNode | null;
+  let audioContext: undefined | AudioContext | null;
   const roleValue = signals.role.value;
   const channelIdValue = signals.channelId.value;
   const googCpuOveruseDetectionValue = signals.googCpuOveruseDetection.value;
@@ -1357,7 +1365,7 @@ export const connectSora = async (): Promise<void> => {
       if (!forceCreateMediaStream && localMediaStreamValue) {
         mediaStream = localMediaStreamValue;
       } else {
-        [mediaStream, gainNode] = await createMediaStream(state).catch((error) => {
+        [mediaStream, gainNode, audioContext] = await createMediaStream(state).catch((error) => {
           signals.setSoraErrorAlertMessage(error.toString());
           signals.setSoraConnectionStatus("disconnected");
           throw error;
@@ -1394,8 +1402,8 @@ export const connectSora = async (): Promise<void> => {
   if (mediaStream && (localMediaStreamValue === null || forceCreateMediaStream)) {
     signals.setLocalMediaStream(mediaStream);
   }
-  if (gainNode) {
-    signals.setFakeContentsGainNode(gainNode);
+  if (audioContext !== undefined) {
+    signals.setFakeContentsAudio(audioContext, gainNode ?? null);
   }
   signals.setSoraConnectionStatus("connected");
   signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("connected"));
@@ -1415,11 +1423,12 @@ export const reconnectSora = async (): Promise<void> => {
   let soraConnection: undefined | ConnectionPublisher | ConnectionSubscriber;
   let mediaStream: undefined | MediaStream;
   let gainNode: undefined | GainNode | null;
+  let audioContext: undefined | AudioContext | null;
   const roleValue = signals.role.value;
   const channelIdValue = signals.channelId.value;
   const googCpuOveruseDetectionValue = signals.googCpuOveruseDetection.value;
   if (roleValue === "sendonly" || roleValue === "sendrecv") {
-    [mediaStream, gainNode] = await createMediaStream(state).catch((error) => {
+    [mediaStream, gainNode, audioContext] = await createMediaStream(state).catch((error) => {
       signals.setSoraErrorAlertMessage(error.toString());
       signals.setSoraConnectionStatus("disconnected");
       throw error;
@@ -1473,8 +1482,8 @@ export const reconnectSora = async (): Promise<void> => {
   if (mediaStream) {
     signals.setLocalMediaStream(mediaStream);
   }
-  if (gainNode) {
-    signals.setFakeContentsGainNode(gainNode);
+  if (audioContext !== undefined) {
+    signals.setFakeContentsAudio(audioContext, gainNode ?? null);
   }
   signals.setSoraConnectionStatus("connected");
   signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("connected"));
@@ -1559,7 +1568,7 @@ export const updateMediaStream = async (): Promise<void> => {
       signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("stop", track));
     }
   }
-  const [mediaStream, gainNode] = await createMediaStream(state).catch((error) => {
+  const [mediaStream, gainNode, audioContext] = await createMediaStream(state).catch((error) => {
     signals.setSoraErrorAlertMessage(error.toString());
     signals.setSoraConnectionStatus("disconnected");
     throw error;
@@ -1579,7 +1588,7 @@ export const updateMediaStream = async (): Promise<void> => {
     }
   }
   signals.setLocalMediaStream(mediaStream);
-  signals.setFakeContentsGainNode(gainNode);
+  signals.setFakeContentsAudio(audioContext, gainNode);
 };
 
 export const setMicDeviceAction = async (micDevice: boolean): Promise<void> => {
@@ -1622,10 +1631,12 @@ export const setMicDeviceAction = async (micDevice: boolean): Promise<void> => {
       videoTrack: state.videoTrack,
       virtualBackgroundProcessor: state.virtualBackgroundProcessor,
     };
-    const [mediaStream, gainNode] = await createMediaStream(pickedState).catch((error) => {
-      signals.setSoraErrorAlertMessage(error.toString());
-      throw error;
-    });
+    const [mediaStream, gainNode, audioContext] = await createMediaStream(pickedState).catch(
+      (error) => {
+        signals.setSoraErrorAlertMessage(error.toString());
+        throw error;
+      },
+    );
     if (mediaStream.getAudioTracks().length > 0) {
       if (soraValue && connectionStatusValue === "connected" && localMediaStreamValue) {
         // Sora 接続中の場合
@@ -1640,7 +1651,7 @@ export const setMicDeviceAction = async (micDevice: boolean): Promise<void> => {
         }
         localMediaStreamValue.addTrack(mediaStream.getAudioTracks()[0]);
       }
-      signals.setFakeContentsGainNode(gainNode);
+      signals.setFakeContentsAudio(audioContext, gainNode);
     }
   } else if (soraValue && connectionStatusValue === "connected" && localMediaStreamValue) {
     // Sora 接続中の場合
@@ -1694,10 +1705,12 @@ export const setCameraDeviceAction = async (cameraDevice: boolean): Promise<void
       videoTrack: state.videoTrack,
       virtualBackgroundProcessor: state.virtualBackgroundProcessor,
     };
-    const [mediaStream, gainNode] = await createMediaStream(pickedState).catch((error) => {
-      signals.setSoraErrorAlertMessage(error.toString());
-      throw error;
-    });
+    const [mediaStream, gainNode, audioContext] = await createMediaStream(pickedState).catch(
+      (error) => {
+        signals.setSoraErrorAlertMessage(error.toString());
+        throw error;
+      },
+    );
     if (mediaStream.getVideoTracks().length > 0) {
       if (soraValue && connectionStatusValue === "connected" && localMediaStreamValue) {
         // Sora 接続中の場合
@@ -1712,7 +1725,7 @@ export const setCameraDeviceAction = async (cameraDevice: boolean): Promise<void
         }
         localMediaStreamValue.addTrack(mediaStream.getVideoTracks()[0]);
       }
-      signals.setFakeContentsGainNode(gainNode);
+      signals.setFakeContentsAudio(audioContext, gainNode);
     }
   } else if (soraValue && connectionStatusValue === "connected" && localMediaStreamValue) {
     // Sora 接続中の場合

--- a/src/app/signals.ts
+++ b/src/app/signals.ts
@@ -119,9 +119,11 @@ export const fakeVideoShowChannelId = signal<boolean>(true);
 export const fakeContents = signal<{
   worker: Worker | null;
   gainNode: GainNode | null;
+  audioContext: AudioContext | null;
 }>({
   worker: null,
   gainNode: null,
+  audioContext: null,
 });
 
 // --- デバイス ---
@@ -323,8 +325,21 @@ export const setFakeVolume = (value: string): void => {
     fakeContents.value.gainNode.gain.setValueAtTime(Number.parseFloat(newVolume), 0);
   }
 };
-export const setFakeContentsGainNode = (gainNode: GainNode | null): void => {
-  fakeContents.value = { ...fakeContents.value, gainNode };
+export const setFakeContentsAudio = (
+  audioContext: AudioContext | null,
+  gainNode: GainNode | null,
+): void => {
+  fakeContents.value = { ...fakeContents.value, gainNode, audioContext };
+};
+// fakeContents の AudioContext を close して signal をクリアする
+// AudioContext は GC で解放されないため明示的に close する必要がある
+// close しないと Chrome のハードウェアコンテキスト上限に到達して NotAllowedError になる
+export const closeFakeContentsAudio = (): void => {
+  const previousAudioContext = fakeContents.value.audioContext;
+  if (previousAudioContext !== null) {
+    void previousAudioContext.close();
+  }
+  fakeContents.value = { ...fakeContents.value, gainNode: null, audioContext: null };
 };
 export const setFakeVideoShowChannelId = (value: boolean): void => {
   fakeVideoShowChannelId.value = value;
@@ -802,7 +817,12 @@ function resetMediaSettingsState(): void {
   ignoreDisconnectWebSocket.value = "";
   forceStereoOutput.value = false;
   fakeVolume.value = "0";
-  fakeContents.value = { worker: null, gainNode: null };
+  // 旧 AudioContext を close してから signal をリセットする
+  const previousAudioContext = fakeContents.value.audioContext;
+  if (previousAudioContext !== null) {
+    void previousAudioContext.close();
+  }
+  fakeContents.value = { worker: null, gainNode: null, audioContext: null };
   cameraDevice.value = true;
   micDevice.value = true;
   googCpuOveruseDetection.value = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,7 @@ export interface SoraDevtoolsState {
   fakeContents: {
     worker: Worker | null;
     gainNode: GainNode | null;
+    audioContext: AudioContext | null;
   };
   fakeVolume: string;
   fakeVideoShowChannelId: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -563,6 +563,7 @@ export function createFakeMediaStream(parameters: FakeMediaStreamConstraints): {
   offscreenCanvas: OffscreenCanvas | null;
   mediaStream: MediaStream;
   gainNode: GainNode | null;
+  audioContext: AudioContext | null;
   frameRate: number;
 } {
   const mediaStream = new MediaStream();
@@ -582,11 +583,12 @@ export function createFakeMediaStream(parameters: FakeMediaStreamConstraints): {
     offscreenCanvas = canvas.transferControlToOffscreen();
   }
   let gainNode: GainNode | null = null;
+  let audioContext: AudioContext | null = null;
   if (parameters.audio) {
-    const AudioContext =
+    const AudioContextCtor =
       globalThis.AudioContext ||
       (globalThis as unknown as Record<string, typeof globalThis.AudioContext>).webkitAudioContext;
-    const audioContext = new AudioContext();
+    audioContext = new AudioContextCtor();
     const oscillator = audioContext.createOscillator();
     const selectedOscillatorType = "sine";
     oscillator.type = selectedOscillatorType;
@@ -599,7 +601,13 @@ export function createFakeMediaStream(parameters: FakeMediaStreamConstraints): {
     mediaStream.addTrack(audioTracks[0]);
     gainNode.gain.setValueAtTime(parameters.volume, 0);
   }
-  return { offscreenCanvas, mediaStream, gainNode, frameRate: parameters.frameRate };
+  return {
+    offscreenCanvas,
+    mediaStream,
+    gainNode,
+    audioContext,
+    frameRate: parameters.frameRate,
+  };
 }
 
 export function parseBooleanString(value: string): boolean | undefined {


### PR DESCRIPTION
## Summary

Issue #0001 の対応。fakeMedia 利用時に AudioContext がリークしハードウェアコンテキスト上限に達して `NotAllowedError` が発生する問題を修正する。

- `createFakeMediaStream` の戻り値に `audioContext` を追加
- `fakeContents` 型 / signal に `audioContext: AudioContext | null` を追加
- `setFakeContentsAudio` / `closeFakeContentsAudio` を追加し旧 AudioContext を確実に close
- `createFakeMediaStreamFromState` で新規生成前に旧 AudioContext を close
- `disposeMedia` / disconnect コールバック / `resetState` で AudioContext を close

## Test plan

- [x] vp check (lint / format / tsc)
- [x] vp test run (vitest)
- [x] playwright e2e (sendonly / recvonly / sendrecv)