### PR TITLE
StatsReport タイマーの構造的問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,11 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] StatsReport タイマーの並行呼び出し蓄積・二重起動・即時停止できない問題を修正する
+  - setInterval から setTimeout チェーンに変更し getStats 完了後に次回をスケジュールする
+  - stopStatsReportTimer を新設し disconnect / disconnect コールバックで即時停止する
+  - startStatsReportTimer の先頭で既存タイマーを停止し再接続時のタイマー増殖を防ぐ
+  - @voluntas
 - [FIX] fakeMedia 利用時に AudioContext がリークしてハードウェアコンテキスト上限に達する問題を修正する
   - createFakeMediaStream の戻り値に audioContext を追加し signal で保持する
   - 解像度変更や再接続などで MediaStream を作り直す際に旧 AudioContext を close する

--- a/issues/closed/0002-fix-stats-report-timer-race.md
+++ b/issues/closed/0002-fix-stats-report-timer-race.md
@@ -1,6 +1,7 @@
 # 0002 StatsReport タイマーの構造的問題を修正する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -117,3 +118,13 @@ function stopStatsReportTimer(): void {
   - `startStatsReportTimer` を連続で呼んでもタイマーが増殖しないこと
   - `getStats` が reject してもタイマーが継続すること
   - `sora` が null になったら次回 schedule が行われないこと
+
+## 解決方法
+
+- `src/app/actions.ts` の `startStatsReportTimer` を `setInterval` + async コールバックから `setTimeout` チェーンに書き換えた。`getStats` 完了後に次回をスケジュールするため並行呼び出しが蓄積しない。
+- モジュールスコープに `statsReportTimerId` を保持し、`stopStatsReportTimer` で `clearTimeout` できるようにした。
+- `startStatsReportTimer` の先頭で既存タイマーを停止し、再接続時のタイマー増殖を防いだ。
+- disconnect コールバックと `disconnectSora` で `stopStatsReportTimer` を呼び、即時停止するようにした。
+- `getStats` が例外を投げてもタイマーが継続するよう `try/catch` で握りつぶす。
+
+備考: ユニットテストはモック禁止のため追加せず、e2e (sendonly / recvonly / sendrecv) で接続〜切断の動作を確認した。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1014,6 +1014,8 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     }
     // fakeMedia 利用時の AudioContext を close する
     signals.closeFakeContentsAudio();
+    // statsReport タイマーを即時停止する。setSora(null) による次回 tick 自滅を待たない
+    stopStatsReportTimer();
     signals.setSora(null);
     signals.setSoraSessionId(null);
     signals.setSoraConnectionId(null);
@@ -1318,16 +1320,41 @@ function cleanupMediaStreamOnError(
   }
 }
 
-// statsReport の定期更新タイマーを開始する
+// statsReport の定期更新タイマー
+// setInterval ではなく setTimeout チェーンにすることで getStats の完了を待ってから
+// 次回をスケジュールする。setInterval だと getStats が長時間かかった際に並行呼び出しが蓄積する
+let statsReportTimerId: ReturnType<typeof setTimeout> | null = null;
+
+function stopStatsReportTimer(): void {
+  if (statsReportTimerId !== null) {
+    clearTimeout(statsReportTimerId);
+    statsReportTimerId = null;
+  }
+}
+
 function startStatsReportTimer(): void {
-  const timerId = setInterval(async () => {
+  // 既存タイマーがあれば停止してから起動する。再接続のたびにタイマーが増殖するのを防ぐ
+  stopStatsReportTimer();
+  const schedule = async (): Promise<void> => {
     const soraValue = signals.sora.value;
-    if (soraValue) {
-      await setStatsReportInternal(soraValue);
-    } else {
-      clearInterval(timerId);
+    if (!soraValue) {
+      statsReportTimerId = null;
+      return;
     }
-  }, 1000);
+    try {
+      await setStatsReportInternal(soraValue);
+    } catch {
+      // getStats のエラーはタイマーを停止させない
+    }
+    if (signals.sora.value !== null) {
+      statsReportTimerId = setTimeout(() => {
+        void schedule();
+      }, 1000);
+    } else {
+      statsReportTimerId = null;
+    }
+  };
+  void schedule();
 }
 
 export const connectSora = async (): Promise<void> => {
@@ -1496,6 +1523,8 @@ export const disconnectSora = async (): Promise<void> => {
   const connectionStatusValue = signals.connectionStatus.value;
   if (soraValue && connectionStatusValue === "connected") {
     signals.setSoraConnectionStatus("disconnecting");
+    // statsReport タイマーを即時停止する
+    stopStatsReportTimer();
     await soraValue.disconnect();
     signals.setSoraConnectionStatus("disconnected");
   }


### PR DESCRIPTION
## Summary

Issue #0002 の対応。StatsReport タイマーの並行呼び出し蓄積・二重タイマー起動・即時停止できない問題を修正する。

- `setInterval` から `setTimeout` チェーンに変更し `getStats` 完了後に次回をスケジュール
- `statsReportTimerId` をモジュールスコープに保持し `stopStatsReportTimer` を新設
- `startStatsReportTimer` の先頭で既存タイマー停止、再接続時の増殖を防止
- `disconnectSora` / disconnect コールバックで即時停止
- `getStats` のエラーはタイマーを継続

## Test plan

- [x] vp check (lint / format / tsc)
- [x] vp test run (vitest)
- [x] playwright e2e (sendonly / recvonly / sendrecv)