### PR TITLE
getDisplayMedia の cameraDevice 誤チェックを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,9 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] getDisplayMedia 利用時に cameraDevice=false で画面共有が行われない問題を修正する
+  - createDisplayMediaStream のガード条件から cameraDevice チェックを除外する
+  - @voluntas
 - [FIX] StatsReport タイマーの並行呼び出し蓄積・二重起動・即時停止できない問題を修正する
   - setInterval から setTimeout チェーンに変更し getStats 完了後に次回をスケジュールする
   - stopStatsReportTimer を新設し disconnect / disconnect コールバックで即時停止する

--- a/issues/closed/0003-fix-display-media-camera-device-check.md
+++ b/issues/closed/0003-fix-display-media-camera-device-check.md
@@ -1,6 +1,7 @@
 # 0003 createDisplayMediaStream の cameraDevice 誤チェックを修正する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -38,3 +39,7 @@ if (!state.video || !state.cameraDevice) {
 
 - `createDisplayMediaStream` に `state.cameraDevice=false, state.video=true` を渡したとき、空の MediaStream ではなく `getDisplayMedia` が呼ばれること
 - `state.video=false` のときは引き続き空の MediaStream が返ること
+
+## 解決方法
+
+`src/app/actions.ts` の `createDisplayMediaStream` のガード条件から `cameraDevice` チェックを除外し `if (!state.video)` のみで判定するようにした。`cameraDevice` はカメラ利用フラグであり画面共有とは無関係。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -657,7 +657,8 @@ async function createDisplayMediaStream(
   state: createMediaStreamPickedState,
 ): Promise<[MediaStream, null, null]> {
   const LOG_TITLE = "MEDIA_CONSTRAINTS";
-  if (!state.video || !state.cameraDevice) {
+  // cameraDevice はカメラ利用フラグなので getDisplayMedia とは無関係。video のみで判定する
+  if (!state.video) {
     return [new MediaStream(), null, null];
   }
   if (navigator.mediaDevices === undefined) {


### PR DESCRIPTION
## Summary

Issue #0003 の対応。`createDisplayMediaStream` のガード条件に `cameraDevice` が含まれていたため、`cameraDevice=false` で `getDisplayMedia` が空の MediaStream を返してしまう問題を修正。

- `if (!state.video || !state.cameraDevice)` を `if (!state.video)` に変更

## Test plan

- [x] vp check
- [x] vp test run
- [x] playwright e2e