### PR TITLE
reconnectSora と void 呼び出しのエラー伝播漏れを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,11 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] reconnectSora と disconnect コールバックでの unhandled promise rejection を修正する
+  - reconnectSora 内の createMediaStream 失敗時に try/catch で捕捉して disconnected 状態へ戻す
+  - disconnect コールバック内の stopLocalVideoTrack に try/catch を追加する
+  - setMicDeviceAction / setCameraDeviceAction の void 呼び出しに catch ハンドラを追加する
+  - @voluntas
 - [FIX] getDisplayMedia 利用時に cameraDevice=false で画面共有が行われない問題を修正する
   - createDisplayMediaStream のガード条件から cameraDevice チェックを除外する
   - @voluntas

--- a/issues/closed/0004-fix-reconnect-sora-error-propagation.md
+++ b/issues/closed/0004-fix-reconnect-sora-error-propagation.md
@@ -1,6 +1,7 @@
 # 0004 reconnectSora のエラー伝播漏れを修正する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -47,3 +48,9 @@ Model: deepseek-v4-pro
 
 - `reconnectSora` で `createMediaStream` が reject した場合、`connectionStatus` が `"disconnected"` になり `reconnecting` が false になること
 - disconnect callback 内の `stopLocalVideoTrack` が throw しても、後続のクリーンアップ処理が継続されること
+
+## 解決方法
+
+- `src/app/actions.ts` の `reconnectSora` で `createMediaStream` 呼び出しを `try/catch` で囲み、失敗時に `setSoraConnectionStatus("disconnected")` と `setSoraReconnecting(false)` を呼んで `return` するようにした。
+- disconnect コールバックの `void IIFE` 内に `try/catch` を追加し、`stopLocalVideoTrack` の例外を `setLogMessages` で記録する。
+- `setMicDeviceAction` の `removeAudioTrack`、`setCameraDeviceAction` の `replaceVideoTrack` / `removeVideoTrack` の `void` 呼び出しを `.catch(...)` 付きに変更し、unhandled rejection を防ぐ。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1001,8 +1001,15 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     const originalTrack = stopVideoProcessors(virtualBackgroundProcessorValue);
     // video track は停止の際に非同期処理が必要なため、最小限の処理に絞って非同期処理にする
     void (async () => {
-      // ローカルの MediaStream の Track と MediaProcessor を止める
-      await stopLocalVideoTrack(localMediaStreamValue, originalTrack);
+      try {
+        // ローカルの MediaStream の Track と MediaProcessor を止める
+        await stopLocalVideoTrack(localMediaStreamValue, originalTrack);
+      } catch (error) {
+        signals.setLogMessages({
+          title: "STOP_LOCAL_VIDEO_TRACK",
+          description: error instanceof Error ? error.message : String(error),
+        });
+      }
     })();
     stopLocalAudioTrack(localMediaStreamValue, noiseSuppressionProcessorValue);
     for (const client of remoteClientsValue) {
@@ -1456,11 +1463,17 @@ export const reconnectSora = async (): Promise<void> => {
   const channelIdValue = signals.channelId.value;
   const googCpuOveruseDetectionValue = signals.googCpuOveruseDetection.value;
   if (roleValue === "sendonly" || roleValue === "sendrecv") {
-    [mediaStream, gainNode, audioContext] = await createMediaStream(state).catch((error) => {
-      signals.setSoraErrorAlertMessage(error.toString());
+    try {
+      [mediaStream, gainNode, audioContext] = await createMediaStream(state);
+    } catch (error) {
+      // createMediaStream の失敗時は再接続を中止し disconnected 状態に戻す
+      if (error instanceof Error) {
+        signals.setSoraErrorAlertMessage(error.toString());
+      }
       signals.setSoraConnectionStatus("disconnected");
-      throw error;
-    });
+      signals.setSoraReconnecting(false);
+      return;
+    }
   }
   for (let i = 1; i <= 10; i++) {
     const reconnectingValue = signals.reconnecting.value;
@@ -1686,7 +1699,12 @@ export const setMicDeviceAction = async (micDevice: boolean): Promise<void> => {
   } else if (soraValue && connectionStatusValue === "connected" && localMediaStreamValue) {
     // Sora 接続中の場合
     stopLocalAudioTrack(localMediaStreamValue, noiseSuppressionProcessorValue);
-    void soraValue.removeAudioTrack(localMediaStreamValue);
+    soraValue.removeAudioTrack(localMediaStreamValue).catch((error: unknown) => {
+      signals.setLogMessages({
+        title: "REMOVE_AUDIO_TRACK",
+        description: error instanceof Error ? error.message : String(error),
+      });
+    });
   } else if (localMediaStreamValue) {
     // Sora は未接続で media access での表示を行っている場合
     // localMediaStream の AudioTrack を停止して MediaStream から Track を削除する
@@ -1744,7 +1762,14 @@ export const setCameraDeviceAction = async (cameraDevice: boolean): Promise<void
     if (mediaStream.getVideoTracks().length > 0) {
       if (soraValue && connectionStatusValue === "connected" && localMediaStreamValue) {
         // Sora 接続中の場合
-        void soraValue.replaceVideoTrack(localMediaStreamValue, mediaStream.getVideoTracks()[0]);
+        soraValue
+          .replaceVideoTrack(localMediaStreamValue, mediaStream.getVideoTracks()[0])
+          .catch((error: unknown) => {
+            signals.setLogMessages({
+              title: "REPLACE_VIDEO_TRACK",
+              description: error instanceof Error ? error.message : String(error),
+            });
+          });
       } else if (localMediaStreamValue) {
         // Sora は未接続で media access での表示を行っている場合
         // 現在の VideoTrack を停止、削除してから、新しい VideoTrack を追加する
@@ -1761,7 +1786,12 @@ export const setCameraDeviceAction = async (cameraDevice: boolean): Promise<void
     // Sora 接続中の場合
     const originalTrack = stopVideoProcessors(virtualBackgroundProcessorValue);
     await stopLocalVideoTrack(localMediaStreamValue, originalTrack);
-    void soraValue.removeVideoTrack(localMediaStreamValue);
+    soraValue.removeVideoTrack(localMediaStreamValue).catch((error: unknown) => {
+      signals.setLogMessages({
+        title: "REMOVE_VIDEO_TRACK",
+        description: error instanceof Error ? error.message : String(error),
+      });
+    });
   } else if (localMediaStreamValue) {
     // Sora は未接続で media access での表示を行っている場合
     // localMediaStream の VideoTrack を停止して MediaStream から Track を削除する


### PR DESCRIPTION
## Summary

Issue #0004 の対応。`reconnectSora` 内の `createMediaStream(state).catch(...)` が外側に try/catch を持たず unhandled rejection になる問題を修正。あわせて disconnect コールバック / mic/camera device action 内の `void` 呼び出しもエラー捕捉する。

- `reconnectSora` の `createMediaStream` を try/catch で囲み、失敗時に disconnected へ戻して return
- disconnect コールバックの IIFE に try/catch を追加
- `removeAudioTrack` / `removeVideoTrack` / `replaceVideoTrack` の `void` 呼び出しに catch ハンドラを追加

## Test plan

- [x] vp check
- [x] vp test run
- [x] playwright e2e