### PR TITLE
アラートメッセージの配列トリミングバグを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,10 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] アラートメッセージの配列トリミングロジックの不具合を修正する
+  - ループ条件が変動する length に依存していたため期待件数より残るバグを修正する
+  - MAX_ALERT_MESSAGES 定数で最大保持件数を明示し slice で確実にトリミングする
+  - @voluntas
 - [FIX] reconnectSora と disconnect コールバックでの unhandled promise rejection を修正する
   - reconnectSora 内の createMediaStream 失敗時に try/catch で捕捉して disconnected 状態へ戻す
   - disconnect コールバック内の stopLocalVideoTrack に try/catch を追加する

--- a/issues/closed/0005-fix-alert-messages-trim-bug.md
+++ b/issues/closed/0005-fix-alert-messages-trim-bug.md
@@ -1,6 +1,7 @@
 # 0005 アラートメッセージの配列トリミングバグを修正する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -63,3 +64,8 @@ if (currentAlertMessages.length >= MAX_ALERT_MESSAGES) {
 - アラートメッセージが 10 件の状態で 11 件目を追加 → 最大 10 件（unshift 後で MAX_ALERT_MESSAGES 件）以下であること
 - アラートメッセージが 9 件の状態ではトリミングが発生しないこと
 - アラートメッセージが 20 件蓄積した状態でも正しくトリミングされること
+
+## 解決方法
+
+- `src/app/signals.ts` で `MAX_ALERT_MESSAGES = 10` 定数を定義し、`setAlertMessagesAndLogMessages` のトリミングを `slice(0, MAX_ALERT_MESSAGES - 1)` に書き換えた。
+- `src/app/app.test.ts` に 9 件 / 10 件 / 20 件のテストケースを追加し、トリミングが期待どおり動作することを確認した。

--- a/src/app/app.test.ts
+++ b/src/app/app.test.ts
@@ -26,6 +26,7 @@ import {
 } from "../constants.ts";
 import { setInitialParameter } from "./actions.ts";
 import {
+  alertMessages,
   apiUrl,
   aspectRatio,
   audio,
@@ -58,6 +59,8 @@ import {
   resizeMode,
   resolution,
   role,
+  setAPIInfoAlertMessage,
+  setSoraInfoAlertMessage,
   showStats,
   signalingNotifyMetadata,
   signalingUrlCandidates,
@@ -454,4 +457,35 @@ test("should handle 'apiUrl'", async () => {
   setLocationSearch({ apiUrl: value });
   await setInitialParameter();
   assert.equal(apiUrl.value, value);
+});
+
+// alertMessages のトリミング動作をテストする
+test("alertMessages: 9 件状態でアラートを追加してもトリミングされない", () => {
+  alertMessages.value = [];
+  for (let i = 0; i < 9; i++) {
+    setSoraInfoAlertMessage(`m${i}`);
+  }
+  assert.equal(alertMessages.value.length, 9);
+  setSoraInfoAlertMessage("m9");
+  assert.equal(alertMessages.value.length, 10);
+});
+
+test("alertMessages: 10 件状態でアラートを追加すると 10 件以下に保たれる", () => {
+  alertMessages.value = [];
+  for (let i = 0; i < 10; i++) {
+    setSoraInfoAlertMessage(`m${i}`);
+  }
+  assert.equal(alertMessages.value.length, 10);
+  setSoraInfoAlertMessage("new");
+  assert.equal(alertMessages.value.length, 10);
+  assert.equal(alertMessages.value[0].message, "new");
+});
+
+test("alertMessages: 20 件分追加しても 10 件以下に保たれる", () => {
+  alertMessages.value = [];
+  for (let i = 0; i < 20; i++) {
+    setAPIInfoAlertMessage(`m${i}`);
+  }
+  assert.equal(alertMessages.value.length, 10);
+  assert.equal(alertMessages.value[0].message, "m19");
 });

--- a/src/app/signals.ts
+++ b/src/app/signals.ts
@@ -185,15 +185,17 @@ export const isFormDisabled = computed(() => {
   return status === "preparing" || status === "connected" || status === "connecting";
 });
 
+// アラートメッセージの最大保持件数。unshift 後にこの件数までトリムする
+const MAX_ALERT_MESSAGES = 10;
+
 // --- ヘルパー関数 ---
 function setAlertMessagesAndLogMessages(alertMessage: AlertMessage): void {
-  const currentAlertMessages = [...alertMessages.value];
+  let currentAlertMessages = [...alertMessages.value];
   const currentLogMessages = [...logMessages.value];
 
-  if (currentAlertMessages.length >= 10) {
-    for (let i = 0; i <= currentAlertMessages.length - 5; i++) {
-      currentAlertMessages.pop();
-    }
+  // unshift 後に MAX_ALERT_MESSAGES 件以下になるよう先にトリムする
+  if (currentAlertMessages.length >= MAX_ALERT_MESSAGES) {
+    currentAlertMessages = currentAlertMessages.slice(0, MAX_ALERT_MESSAGES - 1);
   }
   currentAlertMessages.unshift(alertMessage);
   currentLogMessages.push({


### PR DESCRIPTION
## Summary

Issue #0005 の対応。`setAlertMessagesAndLogMessages` のトリミングループが `pop` で変動する `length` に依存しており、期待件数より多く残るバグを修正する。

- `MAX_ALERT_MESSAGES = 10` 定数を導入
- `slice(0, MAX_ALERT_MESSAGES - 1)` で確実にトリミング
- 9 / 10 / 20 件のテストケースを追加

## Test plan

- [x] vp check
- [x] vp test run (78 passed)
- [x] playwright e2e