### PR TITLE
接続中・準備中の切断が無視される問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,10 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] connecting / preparing 状態で disconnectSora が無視される問題を修正する
+  - connected 以外の連結中状態でも切断と状態リセットを行うようにする
+  - sora が null の場合でも disconnected に戻し reconnecting フラグも解除する
+  - @voluntas
 - [FIX] aspectRatio 21:9 で 20/9 (≈2.222) の誤った値を返していた問題を修正する
   - 21:9 を選んだ際に 21/9 (≈2.333) を返すよう修正する
   - getValueByAspectRatio の 4:3 / 16:9 / 21:9 / 未対応値の単体テストを追加する

--- a/issues/closed/0007-fix-disconnect-during-connecting.md
+++ b/issues/closed/0007-fix-disconnect-during-connecting.md
@@ -1,6 +1,7 @@
 # 0007 接続中・準備中の切断が無視される問題を修正する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -66,3 +67,11 @@ signals.setSoraReconnecting(false);
 - `disconnectSora` を `connectionStatus="preparing"`, `soraValue=null` で呼んだ場合、`connectionStatus` が `"disconnected"` になること
 - `disconnectSora` を `connectionStatus="connecting"`, `soraValue` が存在する場合、`soraValue.disconnect()` が呼ばれること
 - `disconnectSora` を `connectionStatus="disconnected"` で呼んだ場合、二重 disconnect が発生しないこと
+
+## 解決方法
+
+- `src/app/actions.ts` の `disconnectSora` を以下のように書き換えた:
+  - `connectionStatus === "disconnected"` の場合は早期 return で二重 disconnect を防ぐ
+  - 状態に関わらず `stopStatsReportTimer` を呼んでタイマーを即停止する
+  - `connected` / `connecting` / `preparing` のいずれの状態でも `soraValue` があれば `disconnect()` を呼ぶ
+  - `soraValue` が無くても `connectionStatus` を `disconnected` に戻し、`reconnecting` フラグを解除して UI を再有効化する

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1535,13 +1535,24 @@ export const reconnectSora = async (): Promise<void> => {
 export const disconnectSora = async (): Promise<void> => {
   const soraValue = signals.sora.value;
   const connectionStatusValue = signals.connectionStatus.value;
-  if (soraValue && connectionStatusValue === "connected") {
-    signals.setSoraConnectionStatus("disconnecting");
-    // statsReport タイマーを即時停止する
-    stopStatsReportTimer();
-    await soraValue.disconnect();
-    signals.setSoraConnectionStatus("disconnected");
+  // 既に切断済みの場合は何もしない
+  if (connectionStatusValue === "disconnected") {
+    return;
   }
+  // statsReport タイマーは状態に関わらず即時停止する
+  stopStatsReportTimer();
+  if (
+    soraValue &&
+    (connectionStatusValue === "connected" ||
+      connectionStatusValue === "connecting" ||
+      connectionStatusValue === "preparing")
+  ) {
+    signals.setSoraConnectionStatus("disconnecting");
+    await soraValue.disconnect();
+  }
+  // soraValue が存在しない / 切断できない状態でもクリーンアップして UI を再有効化する
+  signals.setSoraConnectionStatus("disconnected");
+  signals.setSoraReconnecting(false);
 };
 
 // デバイス一覧を取得


### PR DESCRIPTION
## Summary

Issue #0007 の対応。`disconnectSora` が `connected` 状態のみ切断していたため、`connecting` / `preparing` 中の Disconnect ボタン押下が無視される問題を修正。

- `connected` / `connecting` / `preparing` のいずれでも切断
- `soraValue` 無しでも `disconnected` に戻し `reconnecting` 解除
- `disconnected` 状態では早期 return で二重 disconnect 防止

## Test plan

- [x] vp check
- [x] vp test run
- [x] playwright e2e