### PR TITLE
updateMediaStream の replaceTrack のエラー処理を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,9 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] updateMediaStream の replaceTrack のエラーが捕捉されない問題を修正する
+  - Promise.allSettled で並列実行し失敗件数をアラートで通知する
+  - @voluntas
 - [FIX] connecting / preparing 状態で disconnectSora が無視される問題を修正する
   - connected 以外の連結中状態でも切断と状態リセットを行うようにする
   - sora が null の場合でも disconnected に戻し reconnecting フラグも解除する

--- a/issues/closed/0008-fix-replace-track-error-handling.md
+++ b/issues/closed/0008-fix-replace-track-error-handling.md
@@ -1,6 +1,7 @@
 # 0008 updateMediaStream の replaceTrack エラー処理を追加する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -73,3 +74,7 @@ if (failures.length > 0) {
 - 全 `replaceTrack` が成功した場合、アラートが表示されないこと
 - 一部の `replaceTrack` が失敗した場合、アラートが表示されること
 - `soraValue.pc` が null の場合、`replaceTrack` が呼ばれずエラーにならないこと
+
+## 解決方法
+
+`src/app/actions.ts` の `updateMediaStream` の `for` ループを `Promise.allSettled` に書き換え、全 track の `replaceTrack` を並列で待機するようにした。失敗件数を集計して `setSoraErrorAlertMessage` で通知する。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1627,19 +1627,28 @@ export const updateMediaStream = async (): Promise<void> => {
     signals.setSoraConnectionStatus("disconnected");
     throw error;
   });
-  for (const track of mediaStream.getTracks()) {
-    if (!soraValue?.pc) {
-      continue;
-    }
-    const sender = soraValue.pc.getSenders().find((s) => {
-      if (!s.track) {
-        return false;
+  // 全トラックの replaceTrack を Promise.allSettled で並列実行し、失敗をまとめて通知する
+  const replaceResults = await Promise.allSettled(
+    mediaStream.getTracks().map(async (track) => {
+      if (!soraValue?.pc) {
+        return;
       }
-      return s.track.kind === track.kind;
-    });
-    if (sender) {
-      void sender.replaceTrack(track);
-    }
+      const sender = soraValue.pc.getSenders().find((s) => {
+        if (!s.track) {
+          return false;
+        }
+        return s.track.kind === track.kind;
+      });
+      if (sender) {
+        await sender.replaceTrack(track);
+      }
+    }),
+  );
+  const failures = replaceResults.filter((result) => result.status === "rejected");
+  if (failures.length > 0) {
+    signals.setSoraErrorAlertMessage(
+      `failed to replace ${failures.length} track(s) of ${replaceResults.length}`,
+    );
   }
   signals.setLocalMediaStream(mediaStream);
   signals.setFakeContentsAudio(audioContext, gainNode);


### PR DESCRIPTION
## Summary

Issue #0008 の対応。`updateMediaStream` 内の `void sender.replaceTrack` のループが reject を捕捉できない問題を修正。

- `Promise.allSettled` で全 track の replaceTrack を並列実行
- 失敗件数を集計してアラート通知

## Test plan

- [x] vp check
- [x] vp test run
- [x] playwright e2e