### PR TITLE
copy2clipboard 失敗時にユーザーへ通知するように修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,11 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] copy2clipboard 失敗時にユーザーへ通知されない問題を修正する
+  - copyToClipboard にリネームし戻り値を Promise<boolean> に変更する
+  - 失敗時に setAPIErrorAlertMessage で通知する
+  - copyURL を async 関数に変更しコピー完了を待ってから history を更新する
+  - @voluntas
 - [FIX] parseMetadata が JSON パース失敗時に生文字列を返していた問題を修正する
   - JSON パース失敗時は undefined を返すようにする
   - parseMetadata の単体テストを追加する

--- a/issues/closed/0010-fix-copy-clipboard-failure.md
+++ b/issues/closed/0010-fix-copy-clipboard-failure.md
@@ -1,6 +1,7 @@
 # 0010 copy2clipboard が失敗時にユーザーに通知されない問題を修正する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -63,3 +64,10 @@ if (success) {
 - `navigator.clipboard` が存在する場合、`writeText` が呼ばれ `true` が返ること
 - `navigator.clipboard` が存在しない場合、`false` が返ること
 - `navigator.clipboard.writeText` が reject した場合の挙動（現状は catch されていないため、必要に応じて try/catch を追加）
+
+## 解決方法
+
+- `src/utils.ts` の `copy2clipboard` を `copyToClipboard` にリネームし、戻り値を `Promise<boolean>` に変更した。`navigator.clipboard` 未対応または `writeText` が reject した場合は `false` を返す。
+- `src/app/actions.ts` の `copyURL` を `async` 関数に変更し、`copyToClipboard` の結果を確認して失敗時は `setAPIErrorAlertMessage` で通知する。`copyURL` 自身も `Promise<boolean>` を返す。
+- `SessionStatusBar.tsx` / `ConnectionStatusBar.tsx` / `CopyLogButton.tsx` の `void copy2clipboard(...)` を `copyToClipboard(...).then(...)` に置き換え、失敗時にアラート通知する。
+- `CopyUrlButton.tsx` を `copyURL()` の boolean を見て成功時のみ "Copied" 表示を出すように修正した。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -15,7 +15,7 @@ import type {
   TimelineMessage,
 } from "./../types.ts";
 import {
-  copy2clipboard,
+  copyToClipboard,
   createAudioConstraints,
   createConnectOptions,
   createFakeMediaConstraints,
@@ -522,8 +522,8 @@ function buildQueryStrings(parameters: Partial<QueryStringParameters>): string[]
   });
 }
 
-// URL をクリップボードにコピーする
-export const copyURL = (): void => {
+// URL をクリップボードにコピーする。成功時 true、失敗時 false を返す
+export const copyURL = async (): Promise<boolean> => {
   const appendAudioVideoParams = signals.role.value !== "recvonly";
   const appendReceiverParams = signals.role.value !== "sendonly";
   const parameters: Partial<QueryStringParameters> = {
@@ -567,8 +567,15 @@ export const copyURL = (): void => {
     mute: signals.mute.value ? true : undefined,
   };
   const queryStrings = buildQueryStrings(parameters);
-  void copy2clipboard(`${location.origin}${location.pathname}?${queryStrings.join("&")}`);
+  const success = await copyToClipboard(
+    `${location.origin}${location.pathname}?${queryStrings.join("&")}`,
+  );
+  if (!success) {
+    signals.setAPIErrorAlertMessage("failed to copy URL to clipboard");
+    return false;
+  }
   globalThis.history.replaceState(null, "", `${location.pathname}?${queryStrings.join("&")}`);
+  return true;
 };
 
 // State に応じて MediaStream インスタンスを生成する

--- a/src/components/DebugPane/CopyLogButton.tsx
+++ b/src/components/DebugPane/CopyLogButton.tsx
@@ -2,7 +2,8 @@ import type { TargetedMouseEvent } from "preact";
 import { useSignal } from "@preact/signals";
 
 import { ClipboardIcon } from "@/components/ClipboardIcon";
-import { copy2clipboard } from "@/utils";
+import { copyToClipboard } from "@/utils";
+import * as signals from "@/app/signals";
 
 interface Props {
   text: string;
@@ -40,12 +41,17 @@ export function CopyLogButton(props: Props) {
   const copied = useSignal(false);
 
   const onClick = (event: TargetedMouseEvent<HTMLButtonElement>): void => {
-    void copy2clipboard(props.text);
     event.currentTarget.blur();
-    copied.value = true;
-    setTimeout(() => {
-      copied.value = false;
-    }, 2000);
+    void copyToClipboard(props.text).then((success) => {
+      if (!success) {
+        signals.setAPIErrorAlertMessage("failed to copy log to clipboard");
+        return;
+      }
+      copied.value = true;
+      setTimeout(() => {
+        copied.value = false;
+      }, 2000);
+    });
   };
 
   if (props.disabled) {

--- a/src/components/Header/CopyUrlButton.tsx
+++ b/src/components/Header/CopyUrlButton.tsx
@@ -6,11 +6,15 @@ export function CopyUrlButton() {
   const copied = useSignal(false);
 
   const onClick = (): void => {
-    copyURL();
-    copied.value = true;
-    setTimeout(() => {
-      copied.value = false;
-    }, 2000);
+    void copyURL().then((success) => {
+      if (!success) {
+        return;
+      }
+      copied.value = true;
+      setTimeout(() => {
+        copied.value = false;
+      }, 2000);
+    });
   };
 
   const baseClasses = `

--- a/src/components/Video/ConnectionStatusBar.tsx
+++ b/src/components/Video/ConnectionStatusBar.tsx
@@ -2,7 +2,8 @@ import type { TargetedMouseEvent } from "preact";
 
 import { Button } from "@/components/ui";
 import { ClipboardIcon } from "@/components/ClipboardIcon";
-import { copy2clipboard } from "@/utils";
+import { copyToClipboard } from "@/utils";
+import * as signals from "@/app/signals";
 
 interface TextBoxProps {
   id?: string;
@@ -11,7 +12,11 @@ interface TextBoxProps {
 }
 function TextBox(props: TextBoxProps) {
   const onClick = (event: TargetedMouseEvent<HTMLButtonElement>): void => {
-    void copy2clipboard(props.text);
+    void copyToClipboard(props.text).then((success) => {
+      if (!success) {
+        signals.setAPIErrorAlertMessage("failed to copy text to clipboard");
+      }
+    });
     event.currentTarget.blur();
   };
   return (

--- a/src/components/Video/SessionStatusBar.tsx
+++ b/src/components/Video/SessionStatusBar.tsx
@@ -2,7 +2,8 @@ import type { TargetedMouseEvent } from "preact";
 
 import { Button } from "@/components/ui";
 import { ClipboardIcon } from "@/components/ClipboardIcon";
-import { copy2clipboard } from "@/utils";
+import { copyToClipboard } from "@/utils";
+import * as signals from "@/app/signals";
 
 interface TextBoxProps {
   id?: string;
@@ -10,7 +11,11 @@ interface TextBoxProps {
 }
 function TextBox(props: TextBoxProps) {
   const onClick = (event: TargetedMouseEvent<HTMLButtonElement>): void => {
-    void copy2clipboard(props.text);
+    void copyToClipboard(props.text).then((success) => {
+      if (!success) {
+        signals.setAPIErrorAlertMessage("failed to copy text to clipboard");
+      }
+    });
     event.currentTarget.blur();
   };
   return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,10 +46,16 @@ export function formatUnixtime(time: number): string {
   return `${year}-${month}-${day} ${hour}:${minute}:${second}.${millisecond}`;
 }
 
-// OS の Clipboard にテキストを書き込む
-export async function copy2clipboard(text: string): Promise<void> {
-  if (navigator.clipboard) {
-    return navigator.clipboard.writeText(text);
+// OS の Clipboard にテキストを書き込む。成功時 true、失敗時 false を返す
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!navigator.clipboard) {
+    return false;
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

Issue #0010 の対応。`copy2clipboard` が `navigator.clipboard` 未対応時や `writeText` reject 時に失敗を呼び出し元へ伝えず、ユーザーへも通知されない問題を修正。

- `copyToClipboard` にリネームし `Promise<boolean>` を返す
- `copyURL` を async に変更し失敗時にアラート通知
- `CopyUrlButton` / `CopyLogButton` / `*StatusBar` を新 API に追従

## Test plan

- [x] vp check
- [x] vp test run
- [x] playwright e2e