### PR TITLE
rpc.ts の rpcMethods への型安全でないアクセスを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,9 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] rpc.ts の conn.rpcMethods への型安全でないアクセスを修正する
+  - Array.isArray による型ガードで rpcMethods が undefined のときも安全に処理する
+  - @voluntas
 - [FIX] copy2clipboard 失敗時にユーザーへ通知されない問題を修正する
   - copyToClipboard にリネームし戻り値を Promise<boolean> に変更する
   - 失敗時に setAPIErrorAlertMessage で通知する

--- a/issues/closed/0011-fix-rpc-type-safety.md
+++ b/issues/closed/0011-fix-rpc-type-safety.md
@@ -1,6 +1,7 @@
 # 0011 rpc.ts の conn.rpcMethods への型安全でないアクセスを修正する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -47,3 +48,7 @@ if (options.showMethodAlert) {
 - `rpcMethods` が `undefined` の場合、`setRPCErrorAlertMessage("rpc_methods in type: offer is empty")` が呼ばれること
 - `rpcMethods` が空配列の場合も同上
 - `rpcMethods` に指定メソッドが含まれていない場合、適切なエラーメッセージが表示されること
+
+## 解決方法
+
+`src/rpc.ts` の `showMethodAlert` ブロックで `(conn as { rpcMethods?: unknown }).rpcMethods` で値を取り出し、`Array.isArray` による型ガードを追加した。これにより `rpcMethods` が `undefined` でもランタイムエラーにならず、空配列と同じ扱いで「rpc_methods in type: offer is empty」のアラートを表示する。

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -17,10 +17,12 @@ export async function rpc(
   options: RpcOptions = DEFAULT_RPC_OPTIONS,
 ): Promise<void> {
   // Show alert if method is not in rpcMethods
+  // sora-js-sdk のバージョン差で rpcMethods が undefined になり得るため型ガードする
   if (options.showMethodAlert) {
-    if (conn.rpcMethods.length === 0) {
+    const methods = (conn as { rpcMethods?: unknown }).rpcMethods;
+    if (!Array.isArray(methods) || methods.length === 0) {
       setRPCErrorAlertMessage("rpc_methods in type: offer is empty");
-    } else if (!conn.rpcMethods.includes(method)) {
+    } else if (!methods.includes(method)) {
       setRPCErrorAlertMessage(`"${method}" is not in rpc_methods in type: offer`);
     }
   }


### PR DESCRIPTION
## Summary

Issue #0011 の対応。`conn.rpcMethods` への直アクセスは sora-js-sdk のバージョン差で `undefined` になる可能性があるため、`Array.isArray` の型ガードを追加。

## Test plan

- [x] vp check
- [x] vp test run
- [x] playwright e2e