### PR TITLE
エラーメッセージとアラートメッセージを規約に準拠させる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,10 @@
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する
   - @voluntas
+- [FIX] エラーメッセージとアラートメッセージを規約に準拠させる
+  - 小文字始まり、末尾ピリオドなし、英語に統一する
+  - SignalingUrlModal の日本語メッセージを英語化する
+  - @voluntas
 - [FIX] rpc.ts の conn.rpcMethods への型安全でないアクセスを修正する
   - Array.isArray による型ガードで rpcMethods が undefined のときも安全に処理する
   - @voluntas

--- a/issues/closed/0012-fix-error-messages-compliance.md
+++ b/issues/closed/0012-fix-error-messages-compliance.md
@@ -1,6 +1,7 @@
 # 0012 エラーメッセージを CLAUDE.md 規約に準拠させる
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -77,3 +78,9 @@ Model: deepseek-v4-pro
 ## テスト戦略
 
 エラーメッセージの文字列変更のみのため、既存テストがあればそれを更新する。新規テストは不要。
+
+## 解決方法
+
+- `src/app/actions.ts` の 12 箇所のエラー / 情報メッセージを小文字始まり・末尾ピリオドなしの英語に書き換えた。
+- `src/workers/fakeVideo.worker.ts` の "Failed to get 2D context" を小文字始まりに変更した。
+- `src/components/Header/SignalingUrlModal.tsx` の日本語メッセージ (`URL は wss:// または ws://...`、`この URL は既に追加されています`) を英語化した。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -669,7 +669,7 @@ async function createDisplayMediaStream(
     return [new MediaStream(), null, null];
   }
   if (navigator.mediaDevices === undefined) {
-    throw new Error("Failed to call getUserMedia. Make sure domain is secure");
+    throw new Error("failed to call getUserMedia, make sure domain is secure");
   }
   const mediaConstraints = {
     // getDisplayMedia では配信する画面の音声を利用するため、デバイス指定 (audioInput) は使わない
@@ -768,7 +768,7 @@ async function createUserMediaStream(
 ): Promise<[MediaStream, null, null]> {
   const LOG_TITLE = "MEDIA_CONSTRAINTS";
   if (navigator.mediaDevices === undefined) {
-    throw new Error("Failed to call getUserMedia. Make sure domain is secure");
+    throw new Error("failed to call getUserMedia, make sure domain is secure");
   }
   const mediaStream = new MediaStream();
   const audioConstraints = createAudioConstraints({
@@ -817,9 +817,7 @@ async function createUserMediaStream(
       signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("start", audioTrack));
       if (state.mediaProcessorsNoiseSuppression && NoiseSuppressionProcessor.isSupported()) {
         if (state.noiseSuppressionProcessor === null) {
-          throw new Error(
-            "Failed to start NoiseSuppressionProcessor. NoiseSuppressionProcessor is 'null'",
-          );
+          throw new Error("failed to start NoiseSuppressionProcessor, processor is null");
         }
         state.noiseSuppressionProcessor.stopProcessing();
         audioTrack = await state.noiseSuppressionProcessor.startProcessing(audioTrack);
@@ -832,9 +830,7 @@ async function createUserMediaStream(
       signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("start", videoTrack));
       if (state.blurRadius !== "" && VirtualBackgroundProcessor.isSupported()) {
         if (state.virtualBackgroundProcessor === null) {
-          throw new Error(
-            "Failed to start VirtualBackgroundProcessor. VirtualBackgroundProcessor is 'null'",
-          );
+          throw new Error("failed to start VirtualBackgroundProcessor, processor is null");
         }
         const options = {
           blurRadius: getBlurRadiusNumber(state.blurRadius),
@@ -862,7 +858,7 @@ async function createMediaStream(
   }
   if (state.mediaType === "mp4Media") {
     if (state.mp4MediaStream === null) {
-      throw new Error("No MP4 file has been selected");
+      throw new Error("no MP4 file has been selected");
     }
     // 指定の MP4 を再生するための MediaStream を返す
     // DevTools ではいったん常に繰り返し再生にしておく
@@ -1039,7 +1035,7 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     signals.setSoraConnectionStatus("disconnected");
     signals.setLocalMediaStream(null);
     signals.removeAllRemoteClients();
-    signals.setSoraInfoAlertMessage("Disconnect Sora.");
+    signals.setSoraInfoAlertMessage("disconnected Sora");
     signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("disconnected"));
     if (event.type === "abend" && reconnectValue) {
       // 再接続処理開始フラグ
@@ -1194,7 +1190,7 @@ export const requestMedia = async (): Promise<void> => {
         title: LOG_TITLE,
         description: JSON.stringify(error.message),
       });
-      signals.setAPIErrorAlertMessage(`Failed to get user devices. ${error.message}`);
+      signals.setAPIErrorAlertMessage(`failed to get user devices: ${error.message}`);
     }
     cleanupMediaStreamOnError(state, mediaStream);
     throw error;
@@ -1427,16 +1423,16 @@ export const connectSora = async (): Promise<void> => {
     // 先に setSora で state を参照できるようにした state の参照を削除
     signals.setSora(null);
     if (error instanceof Error) {
-      signals.setSoraErrorAlertMessage(`Failed to connect Sora. ${error.message}`);
+      signals.setSoraErrorAlertMessage(`failed to connect Sora: ${error.message}`);
     }
     cleanupMediaStreamOnError(state, mediaStream);
     signals.setSoraConnectionStatus("disconnected");
     throw error;
   }
   if (soraConnection === undefined) {
-    throw new Error("Failed to connect Sora. Connection object is 'undefined'");
+    throw new Error("failed to connect Sora, connection object is undefined");
   }
-  signals.setSoraInfoAlertMessage("Succeeded to connect Sora.");
+  signals.setSoraInfoAlertMessage("succeeded to connect Sora");
   await setStatsReportInternal(soraConnection);
   startStatsReportTimer();
   // disconnect 時に stream を止めないためのハック
@@ -1506,7 +1502,7 @@ export const reconnectSora = async (): Promise<void> => {
       }
     } catch (error) {
       if (error instanceof Error) {
-        signals.setSoraErrorAlertMessage(`(trials ${i}) Failed to connect Sora. ${error.message}`);
+        signals.setSoraErrorAlertMessage(`(trials ${i}) failed to connect Sora: ${error.message}`);
       }
       soraConnection = undefined;
     }
@@ -1518,12 +1514,12 @@ export const reconnectSora = async (): Promise<void> => {
     });
   }
   if (soraConnection === undefined) {
-    signals.setSoraErrorAlertMessage("Failed to reconnect Sora.");
+    signals.setSoraErrorAlertMessage("failed to reconnect Sora");
     signals.setSoraConnectionStatus("disconnected");
     signals.setSoraReconnecting(false);
     return;
   }
-  signals.setSoraInfoAlertMessage("Succeeded to reconnect Sora.");
+  signals.setSoraInfoAlertMessage("succeeded to reconnect Sora");
   await setStatsReportInternal(soraConnection);
   startStatsReportTimer();
   signals.setSora(soraConnection);

--- a/src/components/Header/SignalingUrlModal.tsx
+++ b/src/components/Header/SignalingUrlModal.tsx
@@ -84,12 +84,12 @@ export function SignalingUrlModal({ show, onClose, buttonRef }: SignalingUrlModa
       return;
     }
     if (!isValidUrl(trimmedUrl)) {
-      error.value = "URL は wss:// または ws:// で始まる必要があります";
+      error.value = "URL must start with wss:// or ws://";
       return;
     }
     // 重複チェック
     if (urlEntries.value.some((entry) => entry.url === trimmedUrl)) {
-      error.value = "この URL は既に追加されています";
+      error.value = "this URL has already been added";
       return;
     }
     urlEntries.value = [...urlEntries.value, { url: trimmedUrl, enabled: true }];
@@ -173,9 +173,9 @@ export function SignalingUrlModal({ show, onClose, buttonRef }: SignalingUrlModa
     if (value.trim() === "") {
       error.value = "";
     } else if (!isValidUrl(value.trim())) {
-      error.value = "URL は wss:// または ws:// で始まる必要があります";
+      error.value = "URL must start with wss:// or ws://";
     } else if (urlEntries.value.some((entry) => entry.url === value.trim())) {
-      error.value = "この URL は既に追加されています";
+      error.value = "this URL has already been added";
     } else {
       error.value = "";
     }

--- a/src/workers/fakeVideo.worker.ts
+++ b/src/workers/fakeVideo.worker.ts
@@ -105,7 +105,7 @@ self.addEventListener("message", (event: MessageEvent) => {
       ctx = canvas.getContext("2d", { alpha: false });
 
       if (!ctx) {
-        self.postMessage({ type: "error", error: "Failed to get 2D context" });
+        self.postMessage({ type: "error", error: "failed to get 2D context" });
         return;
       }
 


### PR DESCRIPTION
## Summary

Issue #0012 の対応。CLAUDE.md の規約 (小文字始まり / 末尾ピリオドなし / 英語) に違反していたエラー・情報メッセージを修正。

- actions.ts: 12 箇所
- fakeVideo.worker.ts: 1 箇所
- SignalingUrlModal.tsx: 日本語 → 英語

## Test plan

- [x] vp check
- [x] vp test run
- [x] playwright e2e