### PR TITLE
soraConnection.stream = null の SDK ハックを削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,9 @@
   - デフォルト 1000 件、100/500/1000/5000 から選択可能
   - URL パラメータ maxNotifyMessages に対応
   - @voluntas
+- [CHANGE] connectSora の `soraConnection.stream = null` ハックを削除する
+  - sora-js-sdk 2025.2.0 では disconnect で stream を停止しないため不要
+  - @voluntas
 - [CHANGE] DebugPane の API タブを削除する
   - DEBUG_TYPES から api を削除する。`debugType=api` は無効になる
   - 未使用の Api.tsx を削除する

--- a/issues/closed/0014-fix-sdk-stream-null-hack.md
+++ b/issues/closed/0014-fix-sdk-stream-null-hack.md
@@ -1,6 +1,7 @@
 # 0014 soraConnection.stream = null の SDK 内部状態直接改変を調査する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -42,3 +43,9 @@ soraConnection.stream = null;
 
 - ハック解除後、通常の connect → disconnect サイクルでエラーが発生しないこと
 - 再接続シナリオで stream が正しく引き継がれること
+
+## 解決方法
+
+sora-js-sdk 2025.2.0 (`node_modules/.pnpm/sora-js-sdk@2025.2.0/.../sora.mjs`) を確認した結果、`disconnect()` 経路では `this.stream` に対して `getTracks()` や `track.stop()` の呼び出しは発生せず、`initializeConnection()` で `this.stream = null` にリセットされるのみであった。`stream` プロパティは `base.d.ts` で `MediaStream | null` の public プロパティとして公開されている。
+
+したがって `soraConnection.stream = null` のハックは不要と判断し、`src/app/actions.ts` から該当行とコメントを削除した。e2e の sendonly / recvonly / sendrecv は引き続き通っている。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1435,8 +1435,6 @@ export const connectSora = async (): Promise<void> => {
   signals.setSoraInfoAlertMessage("succeeded to connect Sora");
   await setStatsReportInternal(soraConnection);
   startStatsReportTimer();
-  // disconnect 時に stream を止めないためのハック
-  soraConnection.stream = null;
   if (mediaStream && (localMediaStreamValue === null || forceCreateMediaStream)) {
     signals.setLocalMediaStream(mediaStream);
   }


### PR DESCRIPTION
## Summary

Issue #0014 の対応。sora-js-sdk 2025.2.0 のソースを確認した結果、`disconnect()` 経路では `this.stream` の `getTracks()` / `stop()` を呼ばず `initializeConnection()` で `null` リセットするのみだったため、`soraConnection.stream = null` のハックは不要。

- 該当行と "ハック" コメントを削除

## Test plan

- [x] vp check
- [x] vp test run
- [x] playwright e2e (sendonly / recvonly / sendrecv)