### PR TITLE
死にコードと不要なコメントを削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,13 @@
   - デフォルト 1000 件、100/500/1000/5000 から選択可能
   - URL パラメータ maxNotifyMessages に対応
   - @voluntas
+- [CHANGE] 未使用コード・コメント・lint ディレクティブを削除する
+  - `CustomHTMLCanvasElement` / `testVideoResolutionPattern` / utils 版 `isFormDisabled` を削除
+  - `SoraDevtoolsState` の Omit から存在しない `localTestMediaStream` を削除
+  - 不要な `eslint-disable` / `biome-ignore` ディレクティブを削除
+  - `RTCInboundRtpStreamStats` の口語コメントを削除
+  - `utils.pbt.test.ts` の Cline 自動生成コメントを削除
+  - @voluntas
 - [CHANGE] connectSora の `soraConnection.stream = null` ハックを削除する
   - sora-js-sdk 2025.2.0 では disconnect で stream を停止しないため不要
   - @voluntas

--- a/issues/closed/0015-fix-remove-dead-code.md
+++ b/issues/closed/0015-fix-remove-dead-code.md
@@ -1,6 +1,7 @@
 # 0015 コードベースから死にコード・不要なコメントを削除する
 
 Created: 2026-05-09
+Completed: 2026-05-09
 Model: deepseek-v4-pro
 
 ## 概要
@@ -77,3 +78,21 @@ Model: deepseek-v4-pro
 - 削除後に `vp check`（fmt + lint + typecheck）が pass すること
 - 削除後に `vp test run` が pass すること
 - `INSTRUCTIONS` 削除に伴い、`instructions.json` の import が不要になる場合は `constants.ts` の import 行も削除すること
+
+## 解決方法
+
+- `src/types.ts` から未使用の `CustomHTMLCanvasElement` インターフェースを削除した。
+- `src/utils.ts` から未使用の `testVideoResolutionPattern` 関数を削除した。
+- `src/utils.ts` から signals 版に置き換えられた `isFormDisabled` 関数を削除した（callers は `signals.ts` の computed を使用済み）。
+- `src/types.ts` の `DownloadReportParameters` から存在しない `"localTestMediaStream"` を Omit リストから削除した。
+- `src/app/signals.ts` から不要な `// eslint-disable-next-line import/default` を削除した（eslint 不使用）。
+- `src/utils.ts` から不要な `// biome-ignore lint:` を削除した（Biome 不使用）。
+- `src/types.ts` の `RTCInboundRtpStreamStats` 内の口語コメント `// 元々定義されてたやつ` / `// 新しく追加したやつ` を削除した。
+- `src/utils.pbt.test.ts` 冒頭の `// このテストは Cline ... による自動生成です。` コメントを削除した。
+
+備考: 以下は issue では削除候補として挙がっていたが実際には使用されていたため残した。
+
+- `INSTRUCTIONS` (`src/constants.ts`) は `TooltipFormLabel.tsx` / `TooltipFormCheck.tsx` で使用中。
+- `purgeUrlEntriesFromOPFS` (`src/opfs.ts`) は `SignalingUrlModal.tsx` で使用中。
+
+`src/app/actions.ts` の signals 再エクスポートブロックは 50 ファイルからの import に依存しており、削除は別途まとまった移行作業を要するため今回は触っていない。

--- a/src/app/signals.ts
+++ b/src/app/signals.ts
@@ -10,7 +10,6 @@ import type {
 } from "sora-js-sdk";
 
 import packageJSON from "../../package.json";
-// eslint-disable-next-line import/default -- Vite の ?worker サフィックスによる Web Worker インポート
 import FakeVideoWorker from "../workers/fakeVideo.worker.ts?worker";
 import type {
   AlertMessage,

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,11 +208,6 @@ export interface TimelineMessage {
   dataChannelLabel?: string | null;
 }
 
-// HTMLCanvasElement interface に captureStream を追加
-export interface CustomHTMLCanvasElement extends HTMLCanvasElement {
-  captureStream(fps?: number): MediaStream;
-}
-
 // MediaTrackConstraints interface に property を追加
 export interface SoraDevtoolsMediaTrackConstraints extends MediaTrackConstraintSet {
   echoCancellationType?: "system" | "browser";
@@ -271,15 +266,12 @@ export interface RTCMediaStreamTrackStats extends RTCStats {
 // RTCInboundRtpStreamStats に jitterBuffer 関連を追加
 // ref: https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats
 export interface RTCInboundRtpStreamStats extends RTCReceivedRtpStreamStats {
-  // 元々定義されてたやつ
   firCount?: number;
   framesDecoded?: number;
   nackCount?: number;
   pliCount?: number;
   qpSum?: number;
   remoteId?: string;
-
-  // 新しく追加したやつ
   trackIdentifier: string;
   kind: string;
   jitterBufferDelay?: number;
@@ -413,7 +405,6 @@ export type DownloadReportParameters = Omit<
   | "debugType"
   | "fakeContents"
   | "focusedSpotlightConnectionIds"
-  | "localTestMediaStream"
   | "logMessages"
   | "mediaProcessorsNoiseSuppression"
   | "mp4MediaStream"

--- a/src/utils.pbt.test.ts
+++ b/src/utils.pbt.test.ts
@@ -1,5 +1,3 @@
-// このテストは Cline https://cline.bot/ による自動生成です。
-
 import { fc, test } from "@fast-check/vitest";
 import { assert } from "vite-plus/test";
 import {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -243,7 +243,6 @@ export function parseQueryString(searchParams: URLSearchParams): Partial<QuerySt
   const filteredResult: Partial<QueryStringParameters> = {};
   for (const key of Object.keys(result) as Array<keyof Partial<QueryStringParameters>>) {
     if (result[key] !== undefined) {
-      // biome-ignore lint: 型安全なキーによる代入
       (filteredResult as Record<string, unknown>)[key] = result[key];
     }
   }
@@ -269,10 +268,6 @@ export function createSignalingURL(
 
 // 解像度に対応する width と height を返す
 const videoResolutionPattern = /^(\d+)x(\d+)$/;
-
-export function testVideoResolutionPattern(resolution: string): boolean {
-  return videoResolutionPattern.test(resolution);
-}
 
 export function getVideoSizeByResolution(resolution: string): {
   width: number;
@@ -678,17 +673,6 @@ export async function getDevices(): Promise<MediaDeviceInfo[]> {
     // 例外が起きた場合は何もしない
   }
   return [];
-}
-
-// Sora との接続状態に応じて特定の Form を表示するかしないかを返す
-export function isFormDisabled(
-  connectionStatus: SoraDevtoolsState["soraContents"]["connectionStatus"],
-): boolean {
-  return (
-    connectionStatus === "preparing" ||
-    connectionStatus === "connected" ||
-    connectionStatus === "connecting"
-  );
 }
 
 // track の設定情報を返す


### PR DESCRIPTION
## Summary

Issue #0015 の対応。未使用エクスポート・型参照誤り・無効な lint ディレクティブ・口語コメント・自動生成宣伝コメントを削除する。

INSTRUCTIONS / purgeUrlEntriesFromOPFS は実際に使われていたため残した。signals 再エクスポートブロックは 50 ファイルからの依存があり別件として残す。

## Test plan

- [x] vp check
- [x] vp test run
- [x] playwright e2e