### PR TITLE
issue 0021 requestMedia の no-op catch を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,10 @@
   - 未使用の Api.tsx を削除する
   - @voluntas
 
+- [FIX] requestMedia の no-op catch を削除する
+  - `createMediaStream(state).catch((error) => { throw error; })` の catch ハンドラがエラーをそのまま再スローしているだけで実質何もしていなかったため削除する
+  - 直後の try/catch が同じエラーを捕捉するため挙動は変わらない
+  - @voluntas
 - [FIX] forwardingFilter（単数形）を削除し forwardingFilters（複数形）に統一する
   - @voluntas
 - [FIX] アラートメッセージが RPC メソッドのボタンより背面に表示される問題を修正する

--- a/issues/closed/0021-bug-remove-noop-catch-and-unused-variables.md
+++ b/issues/closed/0021-bug-remove-noop-catch-and-unused-variables.md
@@ -1,6 +1,7 @@
 # 0021-bug-remove-noop-catch-and-unused-variables
 
 Created: 2026-05-10
+Completed: 2026-05-10
 Model: deepseek-v4-pro
 
 ## 背景
@@ -38,3 +39,13 @@ lint では検出されない（未使用変数は `no-unused-vars` の対象外
 
 - `.catch((error) => { throw error; })` が削除される
 - `reconnectSora` の未使用変数が削除されるか、`setFakeContentsAudio` が適切に呼ばれる
+
+## 解決方法
+
+### 1. actions.ts:1200-1202 の no-op catch を削除
+
+`requestMedia` 内の `createMediaStream(state).catch((error) => { throw error; })` を `createMediaStream(state)` に置き換えた。直後の try/catch (L1203) が同じエラーを捕捉するため挙動は変わらない。
+
+### 2. reconnectSora の変数について
+
+develop ブランチでは `gainNode` / `audioContext` が `setFakeContentsAudio(audioContext, gainNode ?? null)` (`actions.ts:1571`) で利用されており、未使用ではないため修正不要。issue が起票された `feature/vite-plus-migrate` ブランチ時点では未使用だった可能性があるが、現状の develop には該当しない。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1197,9 +1197,7 @@ export const requestMedia = async (): Promise<void> => {
   let gainNode: undefined | GainNode | null;
   let audioContext: undefined | AudioContext | null;
   try {
-    [mediaStream, gainNode, audioContext] = await createMediaStream(state).catch((error) => {
-      throw error;
-    });
+    [mediaStream, gainNode, audioContext] = await createMediaStream(state);
   } catch (error) {
     if (error instanceof Error) {
       signals.setLogMessages({


### PR DESCRIPTION
## Summary
- `requestMedia` の `createMediaStream(state).catch((error) => { throw error; })` を `createMediaStream(state)` に置き換える
- 直後の try/catch が同じエラーを捕捉するため挙動は変わらない
- `reconnectSora` の `gainNode` / `audioContext` は develop ブランチでは `setFakeContentsAudio` で利用済みのため修正不要

## Test plan
- [x] `pnpm run check` 通過
- [x] `pnpm test` 通過