### PR TITLE
issue 0022 Video.tsx の setSinkId 二重呼び出しを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,10 @@
   - 未使用の Api.tsx を削除する
   - @voluntas
 
+- [FIX] Video.tsx の setSinkId が ResizeObserver 用 useEffect と stream 用 useEffect の両方で発火する問題を修正する
+  - ResizeObserver 用の useEffect から setSinkId 呼び出しを削除し依存配列を `[setHeight]` のみにする
+  - setSinkId は srcObject 設定後の useEffect のみに集約する
+  - @voluntas
 - [FIX] requestMedia の no-op catch を削除する
   - `createMediaStream(state).catch((error) => { throw error; })` の catch ハンドラがエラーをそのまま再スローしているだけで実質何もしていなかったため削除する
   - 直後の try/catch が同じエラーを捕捉するため挙動は変わらない

--- a/issues/closed/0022-bug-fix-duplicate-setsinkid-calls.md
+++ b/issues/closed/0022-bug-fix-duplicate-setsinkid-calls.md
@@ -1,6 +1,7 @@
 # 0022-bug-fix-duplicate-setsinkid-calls
 
 Created: 2026-05-10
+Completed: 2026-05-10
 Model: deepseek-v4-pro
 
 ## 背景
@@ -33,3 +34,7 @@ if (audioOutput && stream.getAudioTracks().length > 0) {
 ## 期待される結果
 
 1 つ目の useEffect から `setSinkId` 呼び出しを削除し、ResizeObserver 専用にする。`setSinkId` の呼び出しは `srcObject` 設定後（3 つ目の useEffect）のみで十分。
+
+## 解決方法
+
+`Video.tsx` の ResizeObserver 用 useEffect から `setSinkId` 呼び出しを削除し、依存配列を `[setHeight]` のみに変更した。これにより `audioOutput` 変更時に発火するのは srcObject 設定後の useEffect のみとなり、`setSinkId` の二重呼び出しが解消する。

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -24,15 +24,12 @@ function VideoElement(props: VideoProps) {
       }
     });
     if (videoRef.current) {
-      if (audioOutput && stream && stream.getAudioTracks().length > 0) {
-        void videoRef.current.setSinkId(audioOutput);
-      }
       resizeObserver.observe(videoRef.current);
     }
     return () => {
       resizeObserver.disconnect();
     };
-  }, [setHeight, audioOutput, stream]);
+  }, [setHeight]);
 
   useEffect(() => {
     if (videoRef.current && mute) {
@@ -70,7 +67,7 @@ function VideoElement(props: VideoProps) {
     videoElement.addEventListener("loadedmetadata", onLoadedMetadata);
 
     videoElement.srcObject = stream;
-    // srcObject 設定後に音声出力先を指定する。render 時の重複呼び出しは削除済み
+    // 音声出力先の指定は srcObject 設定後のこの useEffect に集約する
     if (audioOutput && stream.getAudioTracks().length > 0) {
       void videoElement.setSinkId(audioOutput);
     }


### PR DESCRIPTION
## Summary
- ResizeObserver 用 useEffect から `setSinkId` 呼び出しを削除し依存配列を `[setHeight]` のみにする
- `setSinkId` は srcObject 設定後の useEffect のみに集約する
- `audioOutput` 変更時に `setSinkId` が 2 回発火する問題を解消する

## Test plan
- [x] `pnpm run check` 通過
- [x] `pnpm test` 通過