### PR TITLE
issue 0023 到達不能な switch の default 節を整理する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,10 @@
   - DEBUG_TYPES から api を削除する。`debugType=api` は無効になる
   - 未使用の Api.tsx を削除する
   - @voluntas
+- [CHANGE] 到達不能な switch の default 節を整理する
+  - `TimelineMessages.tsx` の `logType` switch の到達不能な default 節を削除し、sora-js-sdk が新しい logType を追加した際に exhaustiveness-check で検出できるようにする
+  - `utils.ts` の `getBlurRadiusNumber` の default 節を `const _exhaustiveCheck: never = blurRadius;` パターンに置き換え、新しい blur radius が追加された際にコンパイル時に検出できるようにする
+  - @voluntas
 
 - [FIX] Video.tsx の setSinkId が ResizeObserver 用 useEffect と stream 用 useEffect の両方で発火する問題を修正する
   - ResizeObserver 用の useEffect から setSinkId 呼び出しを削除し依存配列を `[setHeight]` のみにする

--- a/issues/closed/0023-design-remove-unreachable-switch-defaults.md
+++ b/issues/closed/0023-design-remove-unreachable-switch-defaults.md
@@ -1,6 +1,7 @@
 # 0023-design-remove-unreachable-switch-defaults
 
 Created: 2026-05-10
+Completed: 2026-05-10
 Model: deepseek-v4-pro
 
 ## 背景
@@ -55,3 +56,13 @@ switch (blurRadius) {
 
 - TimelineMessages.tsx: `default` 節を削除
 - utils.ts: `default: throw Error` を `default: { const _: never = blurRadius; throw ...}` に変更
+
+## 解決方法
+
+### 1. TimelineMessages.tsx
+
+到達不能な `default` 節を削除した。`logType` 型は `"websocket" | "datachannel" | "peerconnection" | "sora" | "sora-devtools"` で網羅済みのため挙動は変わらない。sora-js-sdk が新しい logType を追加した際は TypeScript の exhaustiveness check で検出される。
+
+### 2. utils.ts (getBlurRadiusNumber)
+
+`default` 節を `const _exhaustiveCheck: never = blurRadius;` パターンに変更した。`BLUR_RADIUS = ["", "weak", "medium", "strong"] as const` を網羅済みのため挙動は変わらないが、新しい blur radius を追加した際にコンパイルエラーで検出できる。

--- a/src/components/DebugPane/TimelineMessages.tsx
+++ b/src/components/DebugPane/TimelineMessages.tsx
@@ -87,10 +87,6 @@ function Collapse(props: TimelineMessage) {
       labelComponent = <SoraDevtoolsLabel />;
       break;
     }
-    default: {
-      labelComponent = undefined;
-      break;
-    }
   }
   return (
     <Message title={title} timestamp={timestamp} description={data ?? ""} label={labelComponent} />

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -324,7 +324,8 @@ export function getBlurRadiusNumber(blurRadius: (typeof BLUR_RADIUS)[number]): n
       return 15;
     }
     default: {
-      throw new Error(`unexpected blurRadius value: ${blurRadius as string}`);
+      const _exhaustiveCheck: never = blurRadius;
+      throw new Error(`unexpected blurRadius value: ${_exhaustiveCheck as string}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- `TimelineMessages.tsx` の `logType` switch の到達不能な default 節を削除する
- `utils.ts` の `getBlurRadiusNumber` の default 節を `const _exhaustiveCheck: never = blurRadius;` パターンに置き換える
- 将来 `logType` / `blurRadius` が追加された際に exhaustiveness-check で検出できるようにする

## Test plan
- [x] `pnpm run check` 通過
- [x] `pnpm test` 通過