### PR TITLE
issue 0024 setTrackContentHint ユーティリティを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@
   - デフォルト 1000 件、100/500/1000/5000 から選択可能
   - URL パラメータ maxNotifyMessages に対応
   - @voluntas
+- [ADD] `setTrackContentHint` ユーティリティを追加して contentHint の機能検出を一元化する
+  - `src/utils.ts` に `setTrackContentHint(track, hint)` を追加する
+  - `actions.ts` の `applyTrackSettings` / `createDisplayMediaStream`、`signals.ts` の `setAudioContentHint` / `setVideoContentHint` から重複した `"contentHint" in track` の機能検出と Firefox 非対応コメントを削除して同関数に置き換える
+  - @voluntas
 - [ADD] テストカバレッジを拡充する
   - `utils.pbt.test.ts` を `utils.prop.ts` にリネームし命名規約に揃える
   - vite.config.ts の test.include を `src/**/*.test.ts` / `src/**/*.prop.ts` に変更する

--- a/issues/closed/0024-enhance-extract-contenthint-utility.md
+++ b/issues/closed/0024-enhance-extract-contenthint-utility.md
@@ -1,6 +1,7 @@
 # 0024-enhance-extract-contenthint-utility
 
 Created: 2026-05-10
+Completed: 2026-05-10
 Model: deepseek-v4-pro
 
 ## 背景
@@ -40,3 +41,20 @@ function setTrackContentHint(track: MediaStreamTrack, hint: string): void {
 ```
 
 上記のユーティリティ関数を抽出し、全 5 箇所から呼び出す。
+
+## 解決方法
+
+`src/utils.ts` に以下のユーティリティを追加した。
+
+```typescript
+// MediaStreamTrack に contentHint を設定する
+// contentHint は Firefox が未対応のため "contentHint" in track で機能検出する
+// c.f. https://caniuse.com/mdn-api_mediastreamtrack_contenthint
+export function setTrackContentHint(track: MediaStreamTrack, hint: string): void {
+  if ("contentHint" in track) {
+    track.contentHint = hint;
+  }
+}
+```
+
+`src/app/actions.ts` の `applyTrackSettings` (video / audio 各ループ) と `createDisplayMediaStream` の video ループ、`src/app/signals.ts` の `setAudioContentHint` / `setVideoContentHint` の合計 5 箇所をこの関数の呼び出しに置き換え、重複していた機能検出と Firefox 非対応コメントを 1 箇所に集約した。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -29,6 +29,7 @@ import {
   getMediaStreamTrackProperties,
   parseMetadata,
   parseQueryString,
+  setTrackContentHint,
 } from "./../utils.ts";
 import { loadUrlEntries } from "./../opfs.ts";
 import * as signals from "./signals.ts";
@@ -644,19 +645,13 @@ function getStateForMediaStream(): createMediaStreamPickedState {
 }
 
 // MediaStream のトラックに contentHint と enabled を設定する
-// contentHint は Firefox が未対応のため "contentHint" in track で機能検出する
-// c.f. https://caniuse.com/mdn-api_mediastreamtrack_contenthint
 function applyTrackSettings(mediaStream: MediaStream, state: createMediaStreamPickedState): void {
   for (const track of mediaStream.getVideoTracks()) {
-    if ("contentHint" in track) {
-      track.contentHint = state.videoContentHint;
-    }
+    setTrackContentHint(track, state.videoContentHint);
     track.enabled = state.videoTrack;
   }
   for (const track of mediaStream.getAudioTracks()) {
-    if ("contentHint" in track) {
-      track.contentHint = state.audioContentHint;
-    }
+    setTrackContentHint(track, state.audioContentHint);
     track.enabled = state.audioTrack;
   }
 }
@@ -700,12 +695,8 @@ async function createDisplayMediaStream(
   );
   const stream = await navigator.mediaDevices.getDisplayMedia(mediaConstraints);
   signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("succeed-get-display-media"));
-  // contentHint は Firefox が未対応のため "contentHint" in track で機能検出する
-  // c.f. https://caniuse.com/mdn-api_mediastreamtrack_contenthint
   for (const track of stream.getVideoTracks()) {
-    if ("contentHint" in track) {
-      track.contentHint = state.videoContentHint;
-    }
+    setTrackContentHint(track, state.videoContentHint);
     track.enabled = state.videoTrack;
     signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("start", track));
   }

--- a/src/app/signals.ts
+++ b/src/app/signals.ts
@@ -26,6 +26,7 @@ import type {
   SoraDevtoolsState,
   TimelineMessage,
 } from "../types";
+import { setTrackContentHint } from "../utils.ts";
 
 // --- Audio 関連 ---
 export const audio = signal<boolean>(true);
@@ -233,12 +234,8 @@ export const setAudioCodecType = (value: SoraDevtoolsState["audioCodecType"]): v
 export const setAudioContentHint = (value: SoraDevtoolsState["audioContentHint"]): void => {
   audioContentHint.value = value;
   if (localMediaStream.value) {
-    // contentHint は Firefox が未対応のため "contentHint" in track で機能検出する
-    // c.f. https://caniuse.com/mdn-api_mediastreamtrack_contenthint
     for (const track of localMediaStream.value.getAudioTracks()) {
-      if ("contentHint" in track) {
-        track.contentHint = value;
-      }
+      setTrackContentHint(track, value);
     }
   }
 };
@@ -423,12 +420,8 @@ export const setVideoCodecType = (value: SoraDevtoolsState["videoCodecType"]): v
 export const setVideoContentHint = (value: SoraDevtoolsState["videoContentHint"]): void => {
   videoContentHint.value = value;
   if (localMediaStream.value) {
-    // contentHint は Firefox が未対応のため "contentHint" in track で機能検出する
-    // c.f. https://caniuse.com/mdn-api_mediastreamtrack_contenthint
     for (const track of localMediaStream.value.getVideoTracks()) {
-      if ("contentHint" in track) {
-        track.contentHint = value;
-      }
+      setTrackContentHint(track, value);
     }
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -714,6 +714,15 @@ interface GetMediaStreamTrackProperties {
   getCapabilities: MediaTrackCapabilities | null;
   getSettings: MediaTrackSettings;
 }
+// MediaStreamTrack に contentHint を設定する
+// contentHint は Firefox が未対応のため "contentHint" in track で機能検出する
+// 参照: https://caniuse.com/mdn-api_mediastreamtrack_contenthint
+export function setTrackContentHint(track: MediaStreamTrack, hint: string): void {
+  if ("contentHint" in track) {
+    track.contentHint = hint;
+  }
+}
+
 export function getMediaStreamTrackProperties(
   track: MediaStreamTrack,
 ): GetMediaStreamTrackProperties {


### PR DESCRIPTION
## Summary
- `src/utils.ts` に `setTrackContentHint(track, hint)` を追加する
- `actions.ts` の `applyTrackSettings` / `createDisplayMediaStream`、`signals.ts` の `setAudioContentHint` / `setVideoContentHint` から 5 箇所の重複した機能検出を当該関数に置き換える
- Firefox 非対応コメントを 1 箇所 (utils.ts) に集約する

## Test plan
- [x] `pnpm run check` 通過
- [x] `pnpm test` 通過