### PR TITLE
issue 0025 CLAUDE.md 違反を解消する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -170,6 +170,11 @@
 
 ### misc
 
+- [CHANGE] CLAUDE.md 違反を解消する
+  - `DownloadReportButton.tsx` / `Rpc.tsx` の英語 JSX コメントを日本語化する
+  - `fakeVideo.worker.ts` の末尾コメントを直前行のコメントに移動する
+  - `Video.tsx` の `c.f.` を `参照:` に置き換える
+  - @voluntas
 - [UPDATE] oxlint v1.39.0 で追加されたルールを有効にする
   - typescript/prefer-optional-chain
   - unicorn/require-module-attributes

--- a/issues/closed/0025-fmt-fix-claude-md-violations.md
+++ b/issues/closed/0025-fmt-fix-claude-md-violations.md
@@ -1,6 +1,7 @@
 # 0025-fmt-fix-claude-md-violations
 
 Created: 2026-05-10
+Completed: 2026-05-10
 Model: deepseek-v4-pro
 
 ## 背景
@@ -58,3 +59,21 @@ CLAUDE.md:
 
 - 「コメントは全て日本語」
 - 「コメントに末尾コメントを利用しないこと」
+
+## 解決方法
+
+### 1. DownloadReportButton.tsx:197
+
+`{/* This is a hidden anchor used for programmatic file download */}` を `{/* プログラムからファイルダウンロードを行うための非表示アンカー */}` に置き換えた。
+
+### 2. Rpc.tsx:235,269
+
+`{/* Request */}` を `{/* リクエスト */}` に、`{/* Response */}` を `{/* レスポンス */}` に置き換えた。
+
+### 3. fakeVideo.worker.ts:24-26
+
+末尾コメント `// 65-75%` `// 45-55%` `// 35-45%` を削除し、上の説明コメント行に「彩度は 65-75%、明度 1 は 45-55%、明度 2 は 35-45% の範囲で振動する」と注記を追加した。
+
+### 4. ラテン語 `c.f.` の使用
+
+`Video.tsx:54` の `c.f.` を `参照:` に置き換えた。`actions.ts:648,704` / `signals.ts:237,427` の `c.f.` は issue 0024 (`setTrackContentHint` 抽出) で対象行が削除済みのため別途対応不要。issue 0024 で `utils.ts` に追加した同一コメントは最初から `参照:` 表記とした。

--- a/src/components/DebugPane/Rpc.tsx
+++ b/src/components/DebugPane/Rpc.tsx
@@ -232,7 +232,7 @@ function RpcObjectItem({ rpcObject }: { rpcObject: RpcObject }) {
         {rpcObject.duration !== undefined && <small>{rpcObject.duration.toFixed(2)} ms</small>}
       </div>
 
-      {/* Request */}
+      {/* リクエスト */}
       <div className="mb-3">
         <div className="mb-2" style={{ color: "#fff", fontSize: "0.9rem" }}>
           <strong>Request:</strong>
@@ -266,7 +266,7 @@ function RpcObjectItem({ rpcObject }: { rpcObject: RpcObject }) {
         )}
       </div>
 
-      {/* Response */}
+      {/* レスポンス */}
       {rpcObject.result !== undefined && (
         <div>
           <div className="mb-2" style={{ color: "#fff", fontSize: "0.9rem" }}>

--- a/src/components/Header/DownloadReportButton.tsx
+++ b/src/components/Header/DownloadReportButton.tsx
@@ -194,7 +194,7 @@ export function DownloadReportButton() {
       <Button variant="light" size="sm" className="ml-1" onClick={onClick}>
         Download report
       </Button>
-      {/* This is a hidden anchor used for programmatic file download */}
+      {/* プログラムからファイルダウンロードを行うための非表示アンカー */}
       <a ref={anchorRef} style={{ display: "none" }} />
     </>
   );

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -51,7 +51,7 @@ function VideoElement(props: VideoProps) {
 
     // Chrome で first video frame まで音声が出力されない現象のワークアラウンド
     // 一旦 video tracks を disabled にしておき、 loadedmetadata イベントで有効にする
-    // c.f. https://bugs.chromium.org/p/chromium/issues/detail?id=403710
+    // 参照: https://bugs.chromium.org/p/chromium/issues/detail?id=403710
     let originalEnabled: boolean | undefined;
     for (const track of stream.getVideoTracks()) {
       originalEnabled = track.enabled;

--- a/src/workers/fakeVideo.worker.ts
+++ b/src/workers/fakeVideo.worker.ts
@@ -21,9 +21,10 @@ function drawFrame(): void {
 
   // 背景をグラデーションで描画
   // アニメーションで彩度と明度も少し変化させる
-  const saturation = 70 + Math.sin(animationPhase * 0.7) * 5; // 65-75%
-  const lightness1 = 50 + Math.sin(animationPhase * 0.5) * 5; // 45-55%
-  const lightness2 = 40 + Math.sin(animationPhase * 0.5) * 5; // 35-45%
+  // 彩度は 65-75%、明度 1 は 45-55%、明度 2 は 35-45% の範囲で振動する
+  const saturation = 70 + Math.sin(animationPhase * 0.7) * 5;
+  const lightness1 = 50 + Math.sin(animationPhase * 0.5) * 5;
+  const lightness2 = 40 + Math.sin(animationPhase * 0.5) * 5;
 
   const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
   gradient.addColorStop(0, `hsl(${hue}, ${saturation}%, ${lightness1}%)`);


### PR DESCRIPTION
## Summary
- `DownloadReportButton.tsx` / `Rpc.tsx` の英語 JSX コメントを日本語化する
- `fakeVideo.worker.ts` の末尾コメントを直前行のコメントに移動する
- `Video.tsx` の `c.f.` を `参照:` に置き換える
- `actions.ts` / `signals.ts` の `c.f.` は issue 0024 で該当行が削除済みのため別途対応不要

## Test plan
- [x] `pnpm run check` 通過
- [x] `pnpm test` 通過