### PR TITLE
issue 0028 getErrorMessage ユーティリティを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@
   - デフォルト 1000 件、100/500/1000/5000 から選択可能
   - URL パラメータ maxNotifyMessages に対応
   - @voluntas
+- [ADD] `getErrorMessage` ユーティリティを追加して `error instanceof Error ? error.message : String(error)` を一元化する
+  - `src/utils.ts` に `getErrorMessage(error: unknown): string` を追加する
+  - `actions.ts` 9 箇所と `Rpc.tsx` 1 箇所をこの関数の呼び出しに置き換える
+  - @voluntas
 - [ADD] `setTrackContentHint` ユーティリティを追加して contentHint の機能検出を一元化する
   - `src/utils.ts` に `setTrackContentHint(track, hint)` を追加する
   - `actions.ts` の `applyTrackSettings` / `createDisplayMediaStream`、`signals.ts` の `setAudioContentHint` / `setVideoContentHint` から重複した `"contentHint" in track` の機能検出と Firefox 非対応コメントを削除して同関数に置き換える

--- a/issues/closed/0028-enhance-extract-geterrormessage-utility.md
+++ b/issues/closed/0028-enhance-extract-geterrormessage-utility.md
@@ -1,6 +1,7 @@
 # 0028-enhance-extract-geterrormessage-utility
 
 Created: 2026-05-10
+Completed: 2026-05-10
 Model: deepseek-v4-pro
 
 ## 背景
@@ -26,3 +27,9 @@ export function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 ```
+
+## 解決方法
+
+`src/utils.ts` に上記の `getErrorMessage(error: unknown): string` を追加した。
+
+`src/app/actions.ts` の 9 箇所 (1019, 1413, 1666, 1743, 1756, 1783, 1837, 1850, 1877) と `src/components/DebugPane/Rpc.tsx` の 1 箇所をこの関数呼び出しに置き換えた。`error instanceof Error ? error.message : String(error)` のパターンは `utils.ts` の実装のみが残る形となった。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -26,6 +26,7 @@ import {
   createVideoConstraints,
   getBlurRadiusNumber,
   getDevices,
+  getErrorMessage,
   getMediaStreamTrackProperties,
   parseMetadata,
   parseQueryString,
@@ -1016,7 +1017,7 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
       } catch (error) {
         signals.setLogMessages({
           title: "STOP_LOCAL_VIDEO_TRACK",
-          description: error instanceof Error ? error.message : String(error),
+          description: getErrorMessage(error),
         });
       }
     })();
@@ -1410,7 +1411,7 @@ export const connectSora = async (): Promise<void> => {
       } else {
         [mediaStream, gainNode, audioContext] = await createMediaStream(state).catch(
           (error: unknown) => {
-            const message = error instanceof Error ? error.message : String(error);
+            const message = getErrorMessage(error);
             signals.setSoraErrorAlertMessage(message);
             signals.setSoraConnectionStatus("disconnected");
             throw error;
@@ -1663,7 +1664,7 @@ export const updateMediaStream = async (): Promise<void> => {
   }
   const [mediaStream, gainNode, audioContext] = await createMediaStream(state).catch(
     (error: unknown) => {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       signals.setSoraErrorAlertMessage(message);
       signals.setSoraConnectionStatus("disconnected");
       throw error;
@@ -1740,7 +1741,7 @@ export const setMicDeviceAction = async (micDevice: boolean): Promise<void> => {
     };
     const [mediaStream, gainNode, audioContext] = await createMediaStream(pickedState).catch(
       (error: unknown) => {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = getErrorMessage(error);
         signals.setSoraErrorAlertMessage(message);
         throw error;
       },
@@ -1753,7 +1754,7 @@ export const setMicDeviceAction = async (micDevice: boolean): Promise<void> => {
         } catch (error) {
           signals.setLogMessages({
             title: "REPLACE_AUDIO_TRACK",
-            description: error instanceof Error ? error.message : String(error),
+            description: getErrorMessage(error),
           });
         }
       } else if (localMediaStreamValue) {
@@ -1780,7 +1781,7 @@ export const setMicDeviceAction = async (micDevice: boolean): Promise<void> => {
     } catch (error) {
       signals.setLogMessages({
         title: "REMOVE_AUDIO_TRACK",
-        description: error instanceof Error ? error.message : String(error),
+        description: getErrorMessage(error),
       });
     }
   } else if (localMediaStreamValue) {
@@ -1834,7 +1835,7 @@ export const setCameraDeviceAction = async (cameraDevice: boolean): Promise<void
     };
     const [mediaStream, gainNode, audioContext] = await createMediaStream(pickedState).catch(
       (error: unknown) => {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = getErrorMessage(error);
         signals.setSoraErrorAlertMessage(message);
         throw error;
       },
@@ -1847,7 +1848,7 @@ export const setCameraDeviceAction = async (cameraDevice: boolean): Promise<void
         } catch (error) {
           signals.setLogMessages({
             title: "REPLACE_VIDEO_TRACK",
-            description: error instanceof Error ? error.message : String(error),
+            description: getErrorMessage(error),
           });
         }
       } else if (localMediaStreamValue) {
@@ -1874,7 +1875,7 @@ export const setCameraDeviceAction = async (cameraDevice: boolean): Promise<void
     } catch (error) {
       signals.setLogMessages({
         title: "REMOVE_VIDEO_TRACK",
-        description: error instanceof Error ? error.message : String(error),
+        description: getErrorMessage(error),
       });
     }
   } else if (localMediaStreamValue) {

--- a/src/components/DebugPane/Rpc.tsx
+++ b/src/components/DebugPane/Rpc.tsx
@@ -16,6 +16,7 @@ import { RPC_TEMPLATES } from "@/constants";
 import { rpc } from "@/rpc";
 import type { RpcObject } from "@/types";
 import { JSONInputField } from "@/components/DevtoolsPane/JSONInputField.tsx";
+import { getErrorMessage } from "@/utils";
 
 import { JsonTree } from "./JsonTree.tsx";
 
@@ -80,9 +81,7 @@ function RpcForm() {
         // RPC params は任意の key-value を持つオブジェクトのため Record<string, unknown> に縮約する
         parsedParams = JSON.parse(paramsText) as Record<string, unknown>;
       } catch (error) {
-        setRPCErrorAlertMessage(
-          `invalid JSON in params: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        setRPCErrorAlertMessage(`invalid JSON in params: ${getErrorMessage(error)}`);
         return;
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,11 @@ export function formatUnixtime(time: number): string {
   return `${year}-${month}-${day} ${hour}:${minute}:${second}.${millisecond}`;
 }
 
+// catch で受け取った unknown 値からエラーメッセージを取り出す
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 // OS の Clipboard にテキストを書き込む。成功時 true、失敗時 false を返す
 export async function copyToClipboard(text: string): Promise<boolean> {
   // navigator.clipboard は HTTPS / localhost 以外では undefined になり得る


### PR DESCRIPTION
## Summary
- `src/utils.ts` に `getErrorMessage(error: unknown): string` を追加する
- `actions.ts` 9 箇所と `Rpc.tsx` 1 箇所の `error instanceof Error ? error.message : String(error)` を当該関数呼び出しに置き換える

## Test plan
- [x] `pnpm run check` 通過
- [x] `pnpm test` 通過