### PR TITLE
issue 0029 stopLocalVideoTrack の live collection 反復による競合を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,10 @@
   - `utils.ts` の `getBlurRadiusNumber` の default 節を `const _exhaustiveCheck: never = blurRadius;` パターンに置き換え、新しい blur radius が追加された際にコンパイル時に検出できるようにする
   - @voluntas
 
+- [FIX] stopLocalVideoTrack の getVideoTracks() の live collection 反復で待機中に新規トラックが巻き込まれる問題を修正する
+  - getVideoTracks() の戻り値を最初に配列にコピーしてからループするように変更する
+  - 100ms 待機中に updateMediaStream などが新規トラックを追加した場合でも対象が固定されるようにする
+  - @voluntas
 - [FIX] Video.tsx の setSinkId が ResizeObserver 用 useEffect と stream 用 useEffect の両方で発火する問題を修正する
   - ResizeObserver 用の useEffect から setSinkId 呼び出しを削除し依存配列を `[setHeight]` のみにする
   - setSinkId は srcObject 設定後の useEffect のみに集約する

--- a/issues/closed/0029-bug-fix-live-collection-race-in-stop-video-track.md
+++ b/issues/closed/0029-bug-fix-live-collection-race-in-stop-video-track.md
@@ -1,6 +1,7 @@
 # 0029-bug-fix-live-collection-race-in-stop-video-track
 
 Created: 2026-05-10
+Completed: 2026-05-10
 Model: deepseek-v4-pro
 
 ## 背景
@@ -50,3 +51,7 @@ for (const track of tracks) {
   localMediaStreamValue.removeTrack(track);
 }
 ```
+
+## 解決方法
+
+`stopLocalVideoTrack` の `originalTrack` が未指定の分岐で、`localMediaStreamValue.getVideoTracks()` の戻り値を最初に配列へスプレッドコピーしてからループするように変更した。これにより 100ms 待機中に `updateMediaStream` などが新規トラックを追加しても、`stop()` / `removeTrack()` の対象は最初に取得したトラック群に固定される。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1925,7 +1925,9 @@ const stopLocalVideoTrack = async (
     if (!localMediaStreamValue) {
       return;
     }
-    for (const track of localMediaStreamValue.getVideoTracks()) {
+    // getVideoTracks() は live collection を返すため待機中に新規トラックが追加されても巻き込まないよう先に配列に固定する
+    const tracks = [...localMediaStreamValue.getVideoTracks()];
+    for (const track of tracks) {
       track.enabled = false;
     }
     // track enabled = false から sleep を sleep を入れないと配信側にカメラの最後のコマが残る問題へのハック
@@ -1933,7 +1935,7 @@ const stopLocalVideoTrack = async (
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 100);
     });
-    for (const track of localMediaStreamValue.getVideoTracks()) {
+    for (const track of tracks) {
       track.stop();
       localMediaStreamValue.removeTrack(track);
       signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("stop", track));


### PR DESCRIPTION
## Summary
- `getVideoTracks()` の戻り値を最初に配列へコピーしてからループするように変更する
- 100ms 待機中に `updateMediaStream` などが新規トラックを追加しても対象が固定されるようにする

## Test plan
- [x] `pnpm run check` 通過
- [x] `pnpm test` 通過