### PR TITLE
0040 dev 環境で .env の VITE_SORA_SIGNALING_URL が反映されない問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@
   - `disconnected` 状態で `Disconnect` を押した場合も残留メディアを掃除する
   - `ConnectButton` の `preparing` 中の二重押下を防止する
   - @voluntas
+- [FIX] dev 環境で `.env` の `VITE_SORA_SIGNALING_URL` が反映されなかった問題を修正する
+  - `createSignalingURL` の dev 用フォールバック分岐で参照していた `import.meta.env.NODE_ENV` を `import.meta.env.DEV` に置き換える
+  - `import.meta.env.NODE_ENV` は Vite がクライアントに注入しないキーであり常に `undefined` を返すため `.env` の上書きが無効化されていた
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0040-bug-fix-vite-env-node-env-key.md
+++ b/issues/closed/0040-bug-fix-vite-env-node-env-key.md
@@ -2,7 +2,7 @@
 
 - Priority: High
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-12
 - Model: Opus 4.7
 - Branch: feature/fix-vite-env-node-env-key
 - Polished: 2026-06-09
@@ -63,3 +63,13 @@ if (import.meta.env.NODE_ENV === "development" && import.meta.env.VITE_SORA_SIGN
 - `import.meta.env.NODE_ENV` の参照がコードベースに残っていないこと（grep で 0 件）。
 - `CHANGES.md` の `## develop` の `[FIX]` に上記エントリが追記され、担当者行が付いていること。
 - 既存テスト (`vp test`) が通ること。
+
+## 解決方法
+
+`src/utils.ts` の `createSignalingURL` 関数内の dev 用フォールバック分岐の条件式を `import.meta.env.NODE_ENV === "development"` から `import.meta.env.DEV` に置き換えた。
+
+- 変更ファイル: `src/utils.ts` 1 行 (271 行目)
+- `import.meta.env.NODE_ENV` のコードベース参照は 0 件 (grep 確認)
+- `src/vite-env.d.ts` は設計方針どおり変更なし
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追記
+- `vp test` (114 件) と `vp check` (228 ファイル) が通過することを確認

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -268,7 +268,7 @@ export function createSignalingURL(
     // 空文字列は取り除く
     return signalingUrlCandidates.filter((signalingUrlCandidate) => signalingUrlCandidate !== "");
   }
-  if (import.meta.env.NODE_ENV === "development" && import.meta.env.VITE_SORA_SIGNALING_URL) {
+  if (import.meta.env.DEV && import.meta.env.VITE_SORA_SIGNALING_URL) {
     return import.meta.env.VITE_SORA_SIGNALING_URL;
   }
   const wsProtocol = globalThis.location.protocol === "https:" ? "wss://" : "ws://";


### PR DESCRIPTION
## 概要

`createSignalingURL()` の dev 用フォールバック分岐で参照していた `import.meta.env.NODE_ENV` は Vite がクライアントに注入しないキーであり、ランタイムでは常に `undefined` を返す。結果として `.env` 経由の `VITE_SORA_SIGNALING_URL` 上書きが完全に無効化されていたため、`import.meta.env.DEV` に置き換えて本来の挙動を取り戻す。

## 変更内容

- `src/utils.ts` の `createSignalingURL` の条件式を `import.meta.env.NODE_ENV === "development"` から `import.meta.env.DEV` に置き換える
- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾に対応エントリを追記する
- `issues/0040-bug-fix-vite-env-node-env-key.md` を `issues/closed/` へ移動し `## 解決方法` と `Completed:` を追記する

## 完了条件

- [x] 検証手順 4 / 5 の修正後・本番の期待挙動が両方とも観測できること
- [x] `import.meta.env.NODE_ENV` の参照がコードベースに残っていないこと (grep で 0 件)
- [x] `CHANGES.md` の `## develop` の `[FIX]` に上記エントリが追記され、担当者行が付いていること
- [x] 既存テスト (`vp test`) が通ること

## 関連 issue

- issues/closed/0040-bug-fix-vite-env-node-env-key.md