### PR TITLE
0044 cleanupSoraMediaState を async 化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -206,6 +206,10 @@
   - `createSignalingURL` の dev 用フォールバック分岐で参照していた `import.meta.env.NODE_ENV` を `import.meta.env.DEV` に置き換える
   - `import.meta.env.NODE_ENV` は Vite がクライアントに注入しないキーであり常に `undefined` を返すため `.env` の上書きが無効化されていた
   - @voluntas
+- [FIX] `cleanupSoraMediaState` を async 化して呼び出し元が完了を待てる形にする
+  - `Disconnect` 操作・再接続失敗・`connectSora` 失敗時の各経路でタイムラインに古い `stop` ログが混入する問題を解消する
+  - `stopLocalAudioTrack` の rejection もログに残す（旧来は audio 側のみ無視）
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0044-bug-fix-cleanup-sora-media-state-async.md
+++ b/issues/closed/0044-bug-fix-cleanup-sora-media-state-async.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-12
 - Model: Opus 4.7
 - Branch: feature/fix-cleanup-sora-media-state-async
 - Polished: 2026-06-09
@@ -175,3 +175,17 @@ export const cleanupSoraMediaState = async (): Promise<void> => {
 - 検証手順 5: UI 反応の体感劣化がないこと。
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 既存テスト (`vp test`) および既存 Playwright e2e が通ること。
+
+## 解決方法
+
+`src/app/actions.ts` の `cleanupSoraMediaState` を `async` 関数化し、戻り値を `Promise<void>` に変更した。内部の `void (async () => { await stopLocalVideoTrack(...) })()` の fire-and-forget を撤去し、`stopLocalVideoTrack` / `stopLocalAudioTrack` を `Promise.allSettled` で並列に待つ形に統一した。`signals.setLocalMediaStream(null)` は `await` の前に置き、closed/0030 の「signal 即時 null 化で UI から映像を即座に消す」設計を維持している。
+
+`Promise.allSettled` の結果を `const [videoResult, audioResult] = ...` で分割代入し、それぞれの `rejection` を `STOP_LOCAL_VIDEO_TRACK` / `STOP_LOCAL_AUDIO_TRACK` ラベルで `setLogMessages` に渡す。旧コードでは audio 側の rejection を握り潰していたが、本対応で audio 側もログに残るようになった。
+
+呼び出し 5 箇所のうち disconnect コールバック (`soraConnection.on("disconnect", ...)`) のみ `async (event) => { ... }` 化したうえで末尾で `try { await cleanupSoraMediaState(); } catch (error) { ... }` でログ化し、SDK が戻り値 `Promise` を待たない契約に合わせて fire-and-forget となるよう構成した。残り 4 箇所（`connectSora` の `catch`、`reconnectSora` の `createMediaStream` 失敗パス、`reconnectSora` の `attemptReconnection` 全失敗パス、`disconnectSora` 冒頭）はすべて `await cleanupSoraMediaState();` に変更している。
+
+`src/app/actions.test.ts` の冪等性テストを `async` 化し、`await` 完了後に `localMediaStream` が null である / `await` 完了後に `remoteClients` が空である / 2 回連続で `await` しても例外を投げない、の新規アサーション 3 件を追加した。
+
+`CHANGES.md` の `## develop` の `[FIX]` セクション末尾に対応エントリを追記した。
+
+SDK 主導切断（`abend` / サーバ主導切断 / ネットワーク断）経路は、本 issue の方針通りスコープ外として残しており、関連 issue 0047 / 0048 で補完予定。

--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -45,13 +45,50 @@ test("isConnectionDestroyedNotify は別の event_type のとき false を返す
   assert.equal(isConnectionDestroyedNotify(message), false);
 });
 
-test("cleanupSoraMediaState は初期状態で呼んでも例外を投げない", () => {
+// async 化後も呼び元が await できることと、初期状態 (null・空) では cleanup が状態を変えないこと
+test("cleanupSoraMediaState は初期状態で await しても例外を投げない", async () => {
   remoteClients.value = [];
   localMediaStream.value = null;
   virtualBackgroundProcessor.value = null;
   noiseSuppressionProcessor.value = null;
   fakeContents.value = { worker: null, gainNode: null, audioContext: null };
-  cleanupSoraMediaState();
+  await cleanupSoraMediaState();
+  assert.equal(localMediaStream.value, null);
+  assert.equal(remoteClients.value.length, 0);
+});
+
+// 戻り値が Promise<void> である型上の契約を確認する (await が型エラーにならないこと自体が契約)
+test("cleanupSoraMediaState は await 完了後に localMediaStream が null である", async () => {
+  remoteClients.value = [];
+  localMediaStream.value = null;
+  virtualBackgroundProcessor.value = null;
+  noiseSuppressionProcessor.value = null;
+  fakeContents.value = { worker: null, gainNode: null, audioContext: null };
+  await cleanupSoraMediaState();
+  assert.equal(localMediaStream.value, null);
+});
+
+// async 化後も remoteClients 側の同期掃除 (clearRemoteMediaClients) が消失していないこと
+test("cleanupSoraMediaState は await 完了後に remoteClients が空である", async () => {
+  remoteClients.value = [];
+  localMediaStream.value = null;
+  virtualBackgroundProcessor.value = null;
+  noiseSuppressionProcessor.value = null;
+  fakeContents.value = { worker: null, gainNode: null, audioContext: null };
+  await cleanupSoraMediaState();
+  assert.equal(remoteClients.value.length, 0);
+});
+
+// disconnectSora 冒頭の await と SDK 主導 disconnect ハンドラの fire-and-forget が直列で重なる経路の冪等性
+// in-flight (1 回目の完了前に 2 回目起動) の冪等性は本テストでは検証しない
+test("cleanupSoraMediaState を 2 回連続で await しても例外を投げない", async () => {
+  remoteClients.value = [];
+  localMediaStream.value = null;
+  virtualBackgroundProcessor.value = null;
+  noiseSuppressionProcessor.value = null;
+  fakeContents.value = { worker: null, gainNode: null, audioContext: null };
+  await cleanupSoraMediaState();
+  await cleanupSoraMediaState();
   assert.equal(localMediaStream.value, null);
   assert.equal(remoteClients.value.length, 0);
 });

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1047,7 +1047,7 @@ const clearRemoteMediaClients = (): void => {
 // Sora 切断時の完全なメディア掃除
 // リモート・ローカル両方のメディアリソースを解放する
 // 冪等（null・空で再呼び出ししても安全）
-export const cleanupSoraMediaState = (): void => {
+export const cleanupSoraMediaState = async (): Promise<void> => {
   clearRemoteMediaClients();
   const localMediaStreamValue = signals.localMediaStream.value;
   const virtualBackgroundProcessorValue = signals.virtualBackgroundProcessor.value;
@@ -1055,24 +1055,32 @@ export const cleanupSoraMediaState = (): void => {
   const fakeContentsValue = signals.fakeContents.value;
   // media processor は同期処理で停止する
   const originalTrack = stopVideoProcessors(virtualBackgroundProcessorValue);
-  // video track は停止の際に非同期処理が必要なため、最小限の処理に絞って非同期処理にする
-  void (async () => {
-    try {
-      await stopLocalVideoTrack(localMediaStreamValue, originalTrack);
-    } catch (error) {
-      signals.setLogMessages({
-        title: "STOP_LOCAL_VIDEO_TRACK",
-        description: getErrorMessage(error),
-      });
-    }
-  })();
-  void stopLocalAudioTrack(localMediaStreamValue, noiseSuppressionProcessorValue);
+  // fakeMedia の worker を停止する
   if (fakeContentsValue.worker) {
     fakeContentsValue.worker.postMessage({ type: "stop" });
   }
   // fakeMedia 利用時の AudioContext を close する
   signals.closeFakeContentsAudio();
+  // closed/0030 の安全網: signal を先に null にして UI から映像を即座に消す（同期）
   signals.setLocalMediaStream(null);
+  // 後追いで video / audio track stop を並列に待つ
+  // 旧コードでは audio 側の rejection を握り潰していたが Promise.allSettled で video / audio 双方の rejection をログに残す
+  const [videoResult, audioResult] = await Promise.allSettled([
+    stopLocalVideoTrack(localMediaStreamValue, originalTrack),
+    stopLocalAudioTrack(localMediaStreamValue, noiseSuppressionProcessorValue),
+  ]);
+  if (videoResult.status === "rejected") {
+    signals.setLogMessages({
+      title: "STOP_LOCAL_VIDEO_TRACK",
+      description: getErrorMessage(videoResult.reason),
+    });
+  }
+  if (audioResult.status === "rejected") {
+    signals.setLogMessages({
+      title: "STOP_LOCAL_AUDIO_TRACK",
+      description: getErrorMessage(audioResult.reason),
+    });
+  }
 };
 
 // Sora connection オブジェクトに callback をセットする
@@ -1143,7 +1151,7 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
       removeRemoteClientCleanup(remoteClient.connectionId);
     }
   });
-  soraConnection.on("disconnect", (event) => {
+  soraConnection.on("disconnect", async (event) => {
     const message: Record<string, unknown> = {
       type: event.type,
       title: event.title,
@@ -1159,7 +1167,6 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     }
     signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-on-disconnect", message));
     const reconnectValue = signals.reconnect.value;
-    cleanupSoraMediaState();
     // statsReport タイマーを即時停止する。setSora(null) による次回 tick 自滅を待たない
     stopStatsReportTimer();
     signals.setSora(null);
@@ -1173,6 +1180,17 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     if (event.type === "abend" && reconnectValue) {
       // 再接続処理開始フラグ
       signals.setSoraReconnecting(true);
+    }
+    // SDK は本コールバックの戻り値 Promise を待たないため、cleanup は実質 fire-and-forget となる
+    // SDK 主導切断 (abend / サーバ主導切断 / ネットワーク断) 経路では古い stop ログ混入を完全には解消できない（混入抑制は 0047 / 0048 で補完予定）
+    // cleanup が reject した場合は unhandled rejection を起こさないよう try / catch でログ化する
+    try {
+      await cleanupSoraMediaState();
+    } catch (error) {
+      signals.setLogMessages({
+        title: "CLEANUP_SORA_MEDIA_STATE",
+        description: getErrorMessage(error),
+      });
     }
   });
   soraConnection.on("timeline", (event) => {
@@ -1539,7 +1557,7 @@ export const connectSora = async (): Promise<void> => {
     }
     await cleanupMediaStreamOnError(state, mediaStream);
     // 残留した remoteClients と localMediaStream を掃除し、接続失敗後も UI に映像が残らないようにする
-    cleanupSoraMediaState();
+    await cleanupSoraMediaState();
     signals.setSoraConnectionStatus("disconnected");
     throw error;
   }
@@ -1636,7 +1654,7 @@ export const reconnectSora = async (): Promise<void> => {
       if (error instanceof Error) {
         signals.setSoraErrorAlertMessage(error.message);
       }
-      cleanupSoraMediaState();
+      await cleanupSoraMediaState();
       signals.setSoraConnectionStatus("disconnected");
       signals.setSoraReconnecting(false);
       return;
@@ -1653,7 +1671,7 @@ export const reconnectSora = async (): Promise<void> => {
   );
   if (soraConnection === undefined) {
     signals.setSora(null);
-    cleanupSoraMediaState();
+    await cleanupSoraMediaState();
     signals.setSoraErrorAlertMessage("failed to reconnect Sora");
     signals.setSoraConnectionStatus("disconnected");
     signals.setSoraReconnecting(false);
@@ -1681,7 +1699,8 @@ export const disconnectSora = async (): Promise<void> => {
   // disconnected 状態でも残留メディアを掃除する
   // connected / connecting / preparing 時は SDK への切断通知前にローカル track を止めるが、UI を即座に消すための意図的な順序であり冪等で安全
   // sora-js-sdk の disconnect() は WebSocket / PeerConnection を close するだけでローカル track を停止しないため、切断通知前に止めても例外や ICE エラーは起きない
-  cleanupSoraMediaState();
+  // cleanup の完了 (track stop 含む) を待ってから SDK の disconnect 通知を呼ぶことで、切断完了通知前にローカル track stop が完了することを保証する
+  await cleanupSoraMediaState();
   // statsReport タイマーは状態に関わらず即時停止する
   stopStatsReportTimer();
   // メディア掃除とタイマー停止は済んだので切断済みならここで抜ける


### PR DESCRIPTION
## 概要

`cleanupSoraMediaState` を `async`/`Promise<void>` 化し、呼び出し元が `await` で完了を待てる形にする。`Disconnect` 操作・再接続失敗・`connectSora` 失敗時の各経路でタイムラインに古い `stop` ログが混入する問題を解消する。

## 変更内容

- `cleanupSoraMediaState` の戻り値を `Promise<void>` に変更
- 内部の `void (async () => ...)()` の fire-and-forget を撤去し、`stopLocalVideoTrack` / `stopLocalAudioTrack` を `Promise.allSettled` で並列に待つ形に統一
- `Promise.allSettled` の結果を `[videoResult, audioResult]` で分割代入し、それぞれの `rejection` を `STOP_LOCAL_VIDEO_TRACK` / `STOP_LOCAL_AUDIO_TRACK` ラベルでログ化（旧コードは audio 側の rejection を握り潰していた）
- `signals.setLocalMediaStream(null)` は `await` の前に置き、closed/0030 の「signal 即時 null 化で UI から映像を即座に消す」設計を維持
- 呼び出し 5 箇所のうち disconnect コールバックは `async (event) => { ... }` 化したうえで末尾で `try { await cleanupSoraMediaState(); } catch (error) { ... }` でログ化（SDK が戻り値 `Promise` を待たない契約に合わせて fire-and-forget）
- 残り 4 箇所（`connectSora` の `catch`、`reconnectSora` の `createMediaStream` 失敗・`attemptReconnection` 全失敗、`disconnectSora` 冒頭）は `await cleanupSoraMediaState();` に変更
- `actions.test.ts` の冪等性テストを `async` 化し、新規アサーション 3 件を追加
- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追加

## 完了条件

- [x] `cleanupSoraMediaState` の戻り値が `Promise<void>` である
- [x] 5 呼び出し箇所が修正されている（disconnect コールバックのみ `try/await/catch`、他は `await`）
- [x] 内部構造（`stopVideoProcessors` / `worker.postMessage({ type: "stop" })` / `closeFakeContentsAudio` / `setLocalMediaStream(null)` の呼び出しと順序）が維持されている
- [x] `actions.test.ts` の冪等性テストが async 化され、新規アサーション 3 件と合わせて pass する
- [x] `CHANGES.md` の `## develop` の `[FIX]` 末尾にエントリが追記されている
- [x] 既存テスト (`vp test`) および型チェック (`vp check`) が通る

## 関連 issue

- issues/closed/0044-bug-fix-cleanup-sora-media-state-async.md

## スコープ外

SDK 主導切断（`abend` / サーバ主導切断 / ネットワーク断）経路は本対応のスコープ外であり、関連 issue 0047 / 0048 で補完予定。