### PR TITLE
Playwright の WebServer 起動コマンドにポート番号を指定する

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
   ],
   webServer: {
     // vite で起動している
-    command: "vp dev",
+    command: "vp dev --port 3333",
     url: "http://localhost:3333/",
     reuseExistingServer: !process.env.CI,
     stdout: "pipe",

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,7 +1,12 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { FullConfig } from "@playwright/test";
 
-process.loadEnvFile(path.resolve(process.cwd(), ".env.local"));
+// CI 環境では .env.local が存在しないため、存在確認を行う
+const envPath = path.resolve(process.cwd(), ".env.local");
+if (fs.existsSync(envPath)) {
+  process.loadEnvFile(envPath);
+}
 
 async function globalSetup(_config: FullConfig) {}
 


### PR DESCRIPTION
e2e-test workflow で WebServer が 60000ms タイムアウトしていた問題を修正します。

- `playwright.config.ts` の `webServer.command` を `vp dev --port 3333` に変更
- `package.json` の dev スクリプトと同じポートを使用するように統一
