### PR TITLE
0045 updateMediaStream の切断時 signal 上書きを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -213,6 +213,10 @@
 - [FIX] Log タブの `description` の `JSON.parse` 失敗で `DebugPane` が壊れる問題を修正する
   - デバイス切替・接続切断時にエラーメッセージ素文字列が `description` に入り render が落ちていた経路を `parseLogDescription` の `try` / `catch` で防御する
   - @voluntas
+- [FIX] `updateMediaStream` の `await` 中に切断された場合に signal を上書きしてリソースリークする問題を修正する
+  - 末尾の signal 更新前にガードを追加し、`soraValue` の同一性 / `localMediaStream` / `connectionStatus` から中断を検出する
+  - 中断時は新規生成した `MediaStream` の全 track を `stop()` し、`AudioContext` があれば `close()` してから return する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0045-bug-fix-update-media-stream-after-disconnect.md
+++ b/issues/closed/0045-bug-fix-update-media-stream-after-disconnect.md
@@ -2,7 +2,7 @@
 
 - Priority: High
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-15
 - Model: Opus 4.7
 - Branch: feature/fix-update-media-stream-after-disconnect
 - Polished: 2026-06-15
@@ -175,3 +175,16 @@ signals.setFakeContentsAudio(audioContext, gainNode);
 - 再接続成功直後（`updateMediaStream` 実行中に reconnect が完了したケース）でも誤動作しないこと（ガード条件で捕捉される）。
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 既存テスト（`pnpm test`）および既存 Playwright e2e（`pnpm test:e2e`）が通ること。
+
+## 解決方法
+
+- `src/app/actions.ts` の `updateMediaStream` 末尾、`signals.setLocalMediaStream(mediaStream)` と `signals.setFakeContentsAudio(audioContext, gainNode)` の直前にガード条件を追加する。中断と判定できる場合は新規生成した `mediaStream` の全 track を `stop()` し、`audioContext !== null` なら `void audioContext.close()` してから return する。
+- ガード条件は以下の 4 つの OR で構成する。
+  - `signals.sora.value !== soraValue`（関数開始時の sora と現在の sora が違う = 切断後の再接続で新セッションに移行）
+  - `signals.localMediaStream.value === null`（`disconnectSora` 内の `await cleanupSoraMediaState()` を跨いだ時間窓を捕捉）
+  - `signals.connectionStatus.value === "disconnecting"`（ユーザー操作の disconnect が走行中）
+  - `signals.connectionStatus.value === "disconnected"`（disconnect 完了済みの過渡状態）
+- レビュー指摘を踏まえ、issue 設計方針の `soraValue === null` 条件は採用しない。理由: `requestMedia` プレビュー後 connect 前の `updateMediaStream` 経路（preview 中のデバイス切替）を「異常系」として弾くと、UI の新デバイス切替が機能しなくなるため。本ガード（`signals.sora.value !== soraValue`）は `soraValue === null` のとき参照比較が `null !== null` で false となり、preview 経路は素通りする。
+- ガード経路で停止した track もタイムラインに記録するため、`signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("stop", track))` を併記する。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾（`### misc` の直前）に `[FIX]` エントリを追記する。
+- `/review-diff-code` のレビューを 1 周回し、重要 1 件（`soraValue === null` ガードと preview 経路の干渉）と改善 1・2・4（条件ごとの 1 行コメント / ガード経路のタイムラインログ / コメント表現修正）を反映した。改善 3（`void audioContext.close()` の rejection 握り潰し）は既存 `closeFakeContentsAudio` と同パターンで一貫性を優先し見送った。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1812,6 +1812,31 @@ export const updateMediaStream = async (): Promise<void> => {
       `failed to replace ${failures.length} track(s) of ${replaceResults.length}`,
     );
   }
+  // 関数内の await を跨いだ後に切断が走ると、ここで signal を上書きして UI に新規メディアが復活し
+  // AudioContext がどこからも参照されないままリークする。末尾の signal 更新前に状態を検査し、
+  // 中断と判定できる場合はローカル変数として持っている新規リソースを直接解放して return する。
+  // requestMedia プレビュー後 connect 前の経路では soraValue / signals.sora.value がともに null で
+  // 参照比較が false になり、preview 中の updateMediaStream は素通りする。
+  if (
+    // 関数開始時の sora と現在の sora が異なる場合は切断後の再接続で新セッションに移行している
+    signals.sora.value !== soraValue ||
+    // disconnectSora 内の await cleanupSoraMediaState() を跨いだ時間窓を捕捉する
+    signals.localMediaStream.value === null ||
+    // ユーザー操作の disconnect が走行中 / 完了済みの過渡状態を捕捉する
+    signals.connectionStatus.value === "disconnecting" ||
+    signals.connectionStatus.value === "disconnected"
+  ) {
+    for (const track of mediaStream.getTracks()) {
+      track.stop();
+      // 中断時に破棄した track もタイムラインに記録してデバッグ時に追えるようにする
+      signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("stop", track));
+    }
+    if (audioContext !== null) {
+      // 既存の closeFakeContentsAudio と同じ void パターンで AudioContext を解放する
+      void audioContext.close();
+    }
+    return;
+  }
   signals.setLocalMediaStream(mediaStream);
   signals.setFakeContentsAudio(audioContext, gainNode);
 };


### PR DESCRIPTION
## 概要

`updateMediaStream` が複数の `await` を跨ぐ間に切断が走ると、末尾の `signals.setLocalMediaStream(mediaStream)` と `signals.setFakeContentsAudio(audioContext, gainNode)` が「切断状態の signal」を上書きし、UI に新規メディアが復活し、`AudioContext` がどこからも参照されないままリークしていた問題を修正する。

## 変更内容

- `src/app/actions.ts` の `updateMediaStream` 末尾の signal 更新 2 行の直前にガードを追加する
- ガード条件 (OR):
  - `signals.sora.value !== soraValue` (切断後の再接続で新セッションに移行)
  - `signals.localMediaStream.value === null` (`disconnectSora` 内の `await cleanupSoraMediaState()` 跨ぎを捕捉)
  - `signals.connectionStatus.value === "disconnecting"`
  - `signals.connectionStatus.value === "disconnected"`
- ガード時はローカル変数として持っている新規 `mediaStream` の全 track を `stop()`、`audioContext !== null` なら `void audioContext.close()` してから return する
- ガード経路で停止した track もタイムラインに記録する
- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾に追記する

## 設計判断（issue 設計方針からの差分）

issue 0045 の設計方針 102 行は `soraValue === null` をガード条件に含めていたが、レビューにより `requestMedia` プレビュー後 connect 前の `updateMediaStream` 経路（preview 中のデバイス切替）を巻き込んで機能退行することが判明したため不採用とした。本ガード (`signals.sora.value !== soraValue`) は `soraValue === null` のとき参照比較が `null !== null` で false となり、preview 経路は素通りする。

## 完了条件

- [x] `CHANGES.md` の `## develop` の `[FIX]` 末尾にエントリ追記、担当者行付き
- [x] 既存テスト (`pnpm test`) が通る
- [ ] 手動検証手順 A / B は本 PR レビュー時に確認

## 関連 issue

- issues/closed/0045-bug-fix-update-media-stream-after-disconnect.md