### PR TITLE
0046 reconnectSora 失敗時のメディアリークを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -217,6 +217,11 @@
   - 末尾の signal 更新前にガードを追加し、`soraValue` の同一性 / `localMediaStream` / `connectionStatus` から中断を検出する
   - 中断時は新規生成した `MediaStream` の全 track を `stop()` し、`AudioContext` があれば `close()` してから return する
   - @voluntas
+- [FIX] `reconnectSora` の `attemptReconnection` 全失敗パスで新規 `MediaStream` / `AudioContext` がリークする問題を修正する
+  - 失敗 return 直前で新規生成した `mediaStream` の全 track を `stop()` し `audioContext` を `close()` する
+  - キャンセル経路（Reconnect Toast を閉じる）でも同じガードに入りリークしない
+  - 失敗 / キャンセル時に停止した track はタイムラインに記録してデバッグ時に追えるようにする
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0046-bug-fix-reconnect-failure-media-leak.md
+++ b/issues/closed/0046-bug-fix-reconnect-failure-media-leak.md
@@ -2,7 +2,7 @@
 
 - Priority: High
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-15
 - Model: Opus 4.7
 - Branch: feature/fix-reconnect-failure-media-leak
 - Polished: 2026-06-15
@@ -172,3 +172,12 @@ if (soraConnection === undefined) {
 - 検証手順 D の 16-17 で成功パス（再接続成功）の挙動が変わらないこと。
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 既存テスト（`pnpm test`）および既存 Playwright e2e（`pnpm test:e2e`）が通ること。
+
+## 解決方法
+
+- `src/app/actions.ts` の `reconnectSora` の失敗 return ブロック（`soraConnection === undefined` 直後）に、ローカル変数として持っている新規 `mediaStream` の全 track を `stop()` し、`audioContext` を `close()` する処理を追加する。
+- ガード位置は `signals.setSora(null)` の直前。`updateMediaStream`（0045）の中断ガードと同じ「signal 更新前にローカル変数で stop/close」パターンに揃える。
+- `audioContext` は `let audioContext: undefined | AudioContext | null` で `sendonly` / `sendrecv` 以外の roleValue では `try` 自体がスキップされて `undefined` のまま残るため、`if (audioContext)` の truthy チェックで 3 状態（`undefined` / `null` / `AudioContext`）を一括捕捉する。
+- ガード経路で停止した track もタイムラインに記録するため、`signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("stop", track))` を併記する。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾（`### misc` の直前）に `[FIX]` エントリを追記する。タイムラインログ追加もサブ箇条で明示する。
+- `/review-diff-code` のレビューを 1 周回し、改善 3（CHANGES.md にタイムラインログ追加を記載）を反映した。改善 1・2（コメント追記）は既存コメントで意図が読めるため見送り、改善 4（既存挙動指摘のみ）は対応不要。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1670,6 +1670,22 @@ export const reconnectSora = async (): Promise<void> => {
     mediaStream,
   );
   if (soraConnection === undefined) {
+    // 新規生成した mediaStream / audioContext は signal にセットされていないため、
+    // cleanupSoraMediaState では解放されない。ローカル変数として直接解放してリークを防ぐ。
+    // キャンセル経路 (Reconnect Toast を閉じる) でも attemptReconnection は undefined を返すため
+    // 本ブロックを通り、同じ解放処理でリソースが回収される。
+    if (mediaStream) {
+      for (const track of mediaStream.getTracks()) {
+        track.stop();
+        // 失敗 / キャンセル時に停止した track もタイムラインに記録してデバッグ時に追えるようにする
+        signals.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog("stop", track));
+      }
+    }
+    // audioContext は undefined / null / AudioContext の 3 状態。truthy チェックで一括捕捉する
+    if (audioContext) {
+      // 既存の closeFakeContentsAudio と同じ void パターンで AudioContext を解放する
+      void audioContext.close();
+    }
     signals.setSora(null);
     await cleanupSoraMediaState();
     signals.setSoraErrorAlertMessage("failed to reconnect Sora");


### PR DESCRIPTION
## 概要

`reconnectSora` の `attemptReconnection` 全失敗パスで、新規生成した `mediaStream` / `audioContext` がどこからも参照されないままリークしていた問題を修正する。失敗 return 直前でローカル変数として直接解放する。

## 変更内容

- `src/app/actions.ts` の `reconnectSora` の失敗 return ブロック (`soraConnection === undefined` 直後) に、ローカル変数として持っている新規 `mediaStream` の全 track を `stop()` し `audioContext` を `close()` する処理を追加する
- ガード位置は `signals.setSora(null)` の直前。0045 (`updateMediaStream` の中断ガード) と同じ「signal 更新前にローカル変数で stop/close」パターンに揃える
- `audioContext` は `undefined | null | AudioContext` の 3 状態を `if (audioContext)` の truthy チェックで一括捕捉する
- 失敗 / キャンセル時に停止した track もタイムラインに記録する
- キャンセル経路 (Reconnect Toast を閉じる) でも `attemptReconnection` は `undefined` を返すため同じガードに入りリークしない
- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾に追記する

## 完了条件

- [x] `CHANGES.md` の `## develop` の `[FIX]` 末尾にエントリ追記、担当者行付き
- [x] 既存テスト (`pnpm test`) が通る
- [ ] 手動検証手順 A / B / C / D は本 PR レビュー時に確認

## 関連 issue

- issues/closed/0046-bug-fix-reconnect-failure-media-leak.md