### PR TITLE
0047 setSoraCallbacks の各リスナーに自己同一性チェックを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -222,6 +222,10 @@
   - キャンセル経路（Reconnect Toast を閉じる）でも同じガードに入りリークしない
   - 失敗 / キャンセル時に停止した track はタイムラインに記録してデバッグ時に追えるようにする
   - @voluntas
+- [FIX] `setSoraCallbacks` の各リスナーに自己同一性チェックを追加し、古い接続からの遅延発火が新セッションを破壊する問題を修正する
+  - `sora-js-sdk` にリスナー解除 API が無いため、ハンドラ側で `signals.sora.value === soraConnection` を判定する
+  - `disconnect` / `notify` / `track` / `removetrack` の状態破壊リスクのあるハンドラを必須でガードし、`log` / `push` / `signaling` / `timeline` / `message` / `datachannel` / `switched` / `connected` も整合性のため同パターンを適用する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0047-bug-fix-disconnect-listener-self-check.md
+++ b/issues/closed/0047-bug-fix-disconnect-listener-self-check.md
@@ -2,7 +2,7 @@
 
 - Priority: High
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-15
 - Model: Opus 4.7
 - Branch: feature/fix-disconnect-listener-self-check
 - Polished: 2026-06-15
@@ -189,3 +189,16 @@ disconnect ハンドラ内の `setSoraReconnecting(true)`（abend + reconnect �
 - disconnect ハンドラの `setSoraReconnecting(true)`（abend + reconnect 有効時）が古い接続からは発火しないこと（検証手順 5 で確認）。
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 既存テスト（`pnpm test`）および既存 Playwright e2e（`pnpm test:e2e`）が通ること。
+
+## 解決方法
+
+- `src/app/actions.ts` の `setSoraCallbacks` 関数冒頭に `const isCurrent = (): boolean => signals.sora.value === soraConnection;` ヘルパーを追加する。
+- 必須 4 ハンドラ（`disconnect` / `notify` / `track` / `removetrack`）にガードを入れる:
+  - `disconnect`: SDK イベント発火そのものの timeline 記録 1 の直後で `if (!isCurrent()) return;`（state 操作と記録 2 を skip）
+  - `notify`: ハンドラ先頭で skip（timeline 記録なし）
+  - `track`: ハンドラ先頭で skip（issue 0041 マージ後の thin wrapper 化を見据え、`remoteClients` 破壊リスクが大きいため timeline 含めて完全に skip）
+  - `removetrack`: SDK イベント発火の timeline 記録の直後で skip（`remoteClients` 書き換えを保護）
+- 推奨 8 ハンドラ（`log` / `push` / `signaling` / `timeline` / `message` / `datachannel` / `switched` / `connected`）にも整合性のため同じ `if (!isCurrent()) return;` ガードを追加する。
+- 旧 `disconnect` ハンドラ内の「混入抑制は 0047 / 0048 で補完予定」という issue 番号参照コメント（`shiguredo-issues` 規約違反）を削除する。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾（`### misc` の直前）に `[FIX]` エントリを追記する。
+- `/review-diff-code` のレビューを 1 周回し、致命的 / 重要 / 改善 / 削除候補すべて 0 件で早期終了した。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1085,13 +1085,25 @@ export const cleanupSoraMediaState = async (): Promise<void> => {
 
 // Sora connection オブジェクトに callback をセットする
 function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscriber): void {
+  // sora-js-sdk にはリスナー解除 API (off / removeAllListeners) が無く、reconnectSora で
+  // 旧接続が破棄されても本関数で登録したリスナーは残り続ける。各ハンドラ先頭で
+  // 「自分が現在の signals.sora.value か」を判定し、新セッションの state を破壊しうる
+  // 処理を旧接続のリスナーからは skip する。
+  const isCurrent = (): boolean => signals.sora.value === soraConnection;
   soraConnection.on("log", (title: string, description: Json) => {
+    if (!isCurrent()) {
+      return;
+    }
     signals.setLogMessages({
       title,
       description: JSON.stringify(description),
     });
   });
   soraConnection.on("notify", (message: SoraNotifyMessage, transportType: TransportType) => {
+    // 旧接続からの notify が新セッションの remoteClients を破壊するのを防ぐ
+    if (!isCurrent()) {
+      return;
+    }
     handleSpotlightEvent(message);
     handleConnectionCreatedNotify(message);
     // 他参加者が退出したらリモートクライアントを削除する
@@ -1105,6 +1117,9 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     });
   });
   soraConnection.on("push", (message: SoraPushMessage, transportType: TransportType) => {
+    if (!isCurrent()) {
+      return;
+    }
     signals.setPushMessages({
       timestamp: Date.now(),
       message,
@@ -1112,6 +1127,11 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     });
   });
   soraConnection.on("track", (event: RTCTrackEvent) => {
+    // 旧接続からの track が新セッションの remoteClients に混入するのを防ぐため
+    // timeline 記録も含めて完全に skip する
+    if (!isCurrent()) {
+      return;
+    }
     signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-on-track"));
     const remoteClientsValue = signals.remoteClients.value;
     const mediaStream = remoteClientsValue.find(
@@ -1138,7 +1158,12 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     }
   });
   soraConnection.on("removetrack", (event: MediaStreamTrackEvent) => {
+    // SDK イベント発火そのものは古い接続でも timeline に残す（append-only で state 破壊なし）
     signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-on-removetrack"));
+    // remoteClients 書き換えは新セッションのみ
+    if (!isCurrent()) {
+      return;
+    }
     const remoteClientsValue = signals.remoteClients.value;
     // sora-js-sdk の "track" イベントは常に RTCTrackEvent を渡すため event は non-null
     const remoteClient = remoteClientsValue.find((client) => {
@@ -1165,7 +1190,12 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     if (event.params !== undefined) {
       message.params = event.params;
     }
+    // 記録 1: SDK イベントの発火そのものを記録する。古い接続でも timeline に残す
     signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-on-disconnect", message));
+    // 以降の state 操作は新セッションのみ
+    if (!isCurrent()) {
+      return;
+    }
     const reconnectValue = signals.reconnect.value;
     // statsReport タイマーを即時停止する。setSora(null) による次回 tick 自滅を待たない
     stopStatsReportTimer();
@@ -1176,13 +1206,13 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     signals.setSoraTurnUrl(null);
     signals.setSoraConnectionStatus("disconnected");
     signals.setSoraInfoAlertMessage("disconnected Sora");
+    // 記録 2: アプリ側の状態遷移として記録する。古い接続では skip 済みのためここには来ない
     signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("disconnected"));
     if (event.type === "abend" && reconnectValue) {
       // 再接続処理開始フラグ
       signals.setSoraReconnecting(true);
     }
     // SDK は本コールバックの戻り値 Promise を待たないため、cleanup は実質 fire-and-forget となる
-    // SDK 主導切断 (abend / サーバ主導切断 / ネットワーク断) 経路では古い stop ログ混入を完全には解消できない（混入抑制は 0047 / 0048 で補完予定）
     // cleanup が reject した場合は unhandled rejection を起こさないよう try / catch でログ化する
     try {
       await cleanupSoraMediaState();
@@ -1194,6 +1224,9 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     }
   });
   soraConnection.on("timeline", (event) => {
+    if (!isCurrent()) {
+      return;
+    }
     const message: TimelineMessage = {
       timestamp: Date.now(),
       type: event.type,
@@ -1210,6 +1243,9 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     }
   });
   soraConnection.on("signaling", (event) => {
+    if (!isCurrent()) {
+      return;
+    }
     const message: SignalingMessage = {
       timestamp: Date.now(),
       transportType: event.transportType,
@@ -1219,6 +1255,9 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     signals.setSignalingMessage(message);
   });
   soraConnection.on("message", (event) => {
+    if (!isCurrent()) {
+      return;
+    }
     signals.setDataChannelMessage({
       timestamp: Date.now(),
       label: event.label,
@@ -1226,12 +1265,21 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     });
   });
   soraConnection.on("datachannel", (event) => {
+    if (!isCurrent()) {
+      return;
+    }
     signals.setSoraDataChannels(event.datachannel);
   });
   soraConnection.on("switched", (message) => {
+    if (!isCurrent()) {
+      return;
+    }
     signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-on-switched", message));
   });
   soraConnection.on("connected", (message) => {
+    if (!isCurrent()) {
+      return;
+    }
     signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-on-connected", message));
   });
 }


### PR DESCRIPTION
## 概要

`sora-js-sdk` (`2026.1.0-canary.1`) のリスナー API は `on(kind, callback)` のみで `off` / `removeAllListeners` が存在しない。`reconnectSora` で旧接続を破棄しても `setSoraCallbacks` で登録したリスナーは残り続け、旧接続から遅延発火したイベントが新セッションの state を破壊する経路がある。各リスナー先頭で「自分が現在の `signals.sora.value` か」を判定する自己同一性チェックを導入する。

## 変更内容

- `src/app/actions.ts` の `setSoraCallbacks` 冒頭に `const isCurrent = (): boolean => signals.sora.value === soraConnection;` を追加する
- 必須 4 ハンドラ (`disconnect` / `notify` / `track` / `removetrack`) と推奨 8 ハンドラ (`log` / `push` / `signaling` / `timeline` / `message` / `datachannel` / `switched` / `connected`) の合計 12 ハンドラに `if (!isCurrent()) return;` ガードを入れる
- `disconnect` ハンドラは SDK イベントの timeline 記録 1 の直後で skip し、state 操作と timeline 記録 2 を保護する
- `track` ハンドラは `remoteClients` 破壊リスクが大きいため timeline 記録含めて完全に skip する
- `removetrack` ハンドラは SDK イベントの timeline 記録の直後で skip し、`remoteClients` 書き換えを保護する
- 旧 `disconnect` ハンドラ内の「混入抑制は 0047 / 0048 で補完予定」という issue 番号参照コメント (規約違反) を削除する
- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾に追記する

## 完了条件

- [x] `setSoraCallbacks` 内で `isCurrent()` ヘルパーが 1 度定義され、必須 4 ハンドラと推奨 8 ハンドラの全てに `if (!isCurrent()) return;` ガードが入っている
- [x] `disconnect` ハンドラの `setSoraReconnecting(true)` が `isCurrent()` の false 経路では skip される
- [x] `CHANGES.md` の `## develop` の `[FIX]` 末尾にエントリ追記、担当者行付き
- [x] 既存テスト (`pnpm test`) が通る
- [ ] 手動検証手順 3 / 4 / 5 は本 PR レビュー時に確認

## 関連 issue

- issues/closed/0047-bug-fix-disconnect-listener-self-check.md