### PR TITLE
0050 fakeVideo Worker の frameRate 過剰再帰描画を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -230,6 +230,11 @@
   - `<Reconnect />` の `useEffect` 起動を撤廃し、abend ハンドラから直接 `reconnectSora` を呼び出すように集約する
   - `reconnectSora` 自体にもモジュールローカルな in-flight `Promise` によるガードを追加する
   - @voluntas
+- [FIX] `fakeVideo` Worker の描画ループが `frameRate` 0 / 負数 / 小数で過剰再帰描画に陥る問題を修正する
+  - `createFakeMediaConstraints` で `parsedFrameRate` を「有限正数のみ受理、上限 60 にクランプ」に厳格化する
+  - 0 / 負数 / 小数 / 16 進数表記は 30 にフォールバックし、60 超は 60 にクランプする
+  - `fakeVideo.worker.ts` の `init` ハンドラでも `[1, 60]` にクランプして二重防御する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0050-bug-fix-fake-video-worker-busy-loop.md
+++ b/issues/closed/0050-bug-fix-fake-video-worker-busy-loop.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/fix-fake-video-worker-busy-loop
 - Polished: 2026-06-16
@@ -279,3 +279,11 @@ CLAUDE.md「後方互換性は考慮しないこと」方針により、後方�
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 追加した単体テスト 4 件 + PBT 1 件が pass すること。
 - 既存テスト（`pnpm test`）および既存 Playwright e2e が通ること。
+
+## 解決方法
+
+- `src/utils.ts` の `createFakeMediaConstraints` を修正し、`parsedFrameRate` を `Number.isFinite(fps) && fps > 0 ? Math.min(fps, 60) : 30` で算出するように厳格化した。これにより `0` / 負数 / `0.5` / `0xN` プレフィックス値は 30 にフォールバックし、60 を超える値は 60 にクランプされる。戻り値 `frameRate` は常に `[1, 60]` の整数になる不変条件をコメントで明示した。
+- `src/workers/fakeVideo.worker.ts` の `init` ハンドラに二重防御を追加した。受信した `data.frameRate` を `Math.floor` で整数化したうえで `> 0` 判定を行い、`Number.isFinite && > 0` を満たすときのみ `[1, 60]` に再クランプする。構造化クローン経由で `NaN` / `Infinity` / 負数 / 小数が届いた場合も 30 にフォールバックする。
+- `src/utils.test.ts` に `createFakeMediaConstraints` の単体テスト 4 件を追加した。`"0"` → 30、`"1"` → 1、`"60"` → 60、`"99999"` → 60 の境界値挙動を確認する。
+- `src/utils.prop.ts` に PBT 1 件を追加した。`"0"` / `"-1"` / `"0.5"` / `"0xFF"` / `"1e5"` / `"Infinity"` / `"NaN"` / `"abc"` / `""` などの代表値と整数・浮動小数・任意文字列を含む `oneof` 入力に対して、戻り値 `frameRate` が常に `[1, 60]` の整数になる不変条件を検証する。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾に `fakeVideo` Worker 過剰再帰描画修正のエントリを追加した。

--- a/src/utils.prop.ts
+++ b/src/utils.prop.ts
@@ -25,6 +25,7 @@ import {
   VIDEO_CONTENT_HINTS,
 } from "./constants.ts";
 import {
+  createFakeMediaConstraints,
   formatUnixtime,
   getVideoSizeByResolution,
   parseBooleanString,
@@ -424,3 +425,48 @@ test.prop([fc.string().filter((s) => !/^\d+x\d+$/u.test(s))])(
     assert.equal(result.height, 0);
   },
 );
+
+// createFakeMediaConstraints の frameRate 不変条件 PBT。
+// Number.parseInt(_, 10) は "e" 以降や "x" 以降を読まないため、文字列の見た目と評価値は乖離する。
+// 30 フォールバック経路: "0" / "-1" / "-0" / "0.5" / "0xFF" (parseInt で 0) / "Infinity" / "-Infinity" / "NaN" / "abc" / ""
+// 1 のまま通過する経路: "1e5" / "1e308" (parseInt で 1)
+// 60 クランプ経路: WebIDL long 全域整数列の極端値 (61 以上の生成値)
+// 正常範囲経路: 1..60 の整数列
+// IEEE 754 の極端値 ("-0" / "5e-324" / "1e308" / "-Infinity") は parseInt の e 不読仕様の境界を踏むが、
+// 結果は先頭整数部 (5 / 1 / NaN) を経て [1, 60] 不変条件を満たす。
+// fc.string() は "60abc" のような部分整数文字列も生成するが、parseInt は先頭整数部 60 を抽出して同じく不変条件を満たす。
+// volume: "0" 固定は Number.parseFloat("") === NaN を避け、frameRate 検証に集中させるため。
+test.prop([
+  fc.oneof(
+    fc.constant("0"),
+    fc.constant("-0"),
+    fc.constant("-1"),
+    fc.constant("0.5"),
+    fc.constant("0xFF"),
+    fc.constant("1e5"),
+    fc.constant("1e308"),
+    fc.constant("5e-324"),
+    fc.constant("Infinity"),
+    fc.constant("-Infinity"),
+    fc.constant("NaN"),
+    fc.constant("abc"),
+    fc.constant(""),
+    fc.integer({ min: 1, max: 60 }).map(String),
+    fc.integer({ min: -2_147_483_648, max: 2_147_483_647 }).map(String),
+    fc.float({ noNaN: true, noDefaultInfinity: true }).map(String),
+    fc.string(),
+  ),
+])("createFakeMediaConstraints の frameRate は常に [1, 60] の整数になる", (raw) => {
+  const result = createFakeMediaConstraints({
+    audio: false,
+    video: true,
+    frameRate: raw,
+    resolution: "",
+    volume: "0",
+    aspectRatio: "",
+    resizeMode: "",
+  });
+  assert.isTrue(Number.isInteger(result.frameRate));
+  assert.isAtLeast(result.frameRate, 1);
+  assert.isAtMost(result.frameRate, 60);
+});

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -22,7 +22,12 @@ import {
   VIDEO_CODEC_TYPES,
   VIDEO_CONTENT_HINTS,
 } from "./constants.ts";
-import { getValueByAspectRatio, parseMetadata, parseQueryString } from "./utils.ts";
+import {
+  createFakeMediaConstraints,
+  getValueByAspectRatio,
+  parseMetadata,
+  parseQueryString,
+} from "./utils.ts";
 
 // テスト用のヘルパー関数
 function createSearchParams(parameters: Record<string, unknown>): URLSearchParams {
@@ -260,4 +265,58 @@ test("parseMetadata: 無効な JSON は undefined を返す", () => {
 
 test("parseMetadata: 空文字列も undefined を返す", () => {
   assert.equal(parseMetadata(true, ""), undefined);
+});
+
+// createFakeMediaConstraints の frameRate 境界値テスト
+// 0 / 負数 / 上限超過は worker の暴走描画につながるため utils 側でクランプする責務を確認する
+test("createFakeMediaConstraints は frameRate に '0' を渡すと parsedFrameRate を 30 に補正する", () => {
+  const result = createFakeMediaConstraints({
+    audio: false,
+    video: true,
+    frameRate: "0",
+    resolution: "",
+    volume: "0",
+    aspectRatio: "",
+    resizeMode: "",
+  });
+  assert.equal(result.frameRate, 30);
+});
+
+test("createFakeMediaConstraints は frameRate に '1' を渡すと parsedFrameRate を 1 に保つ (下限境界)", () => {
+  const result = createFakeMediaConstraints({
+    audio: false,
+    video: true,
+    frameRate: "1",
+    resolution: "",
+    volume: "0",
+    aspectRatio: "",
+    resizeMode: "",
+  });
+  assert.equal(result.frameRate, 1);
+});
+
+test("createFakeMediaConstraints は frameRate に '60' を渡すと parsedFrameRate を 60 に保つ (上限境界)", () => {
+  const result = createFakeMediaConstraints({
+    audio: false,
+    video: true,
+    frameRate: "60",
+    resolution: "",
+    volume: "0",
+    aspectRatio: "",
+    resizeMode: "",
+  });
+  assert.equal(result.frameRate, 60);
+});
+
+test("createFakeMediaConstraints は frameRate に '99999' を渡すと parsedFrameRate を 60 にクランプする", () => {
+  const result = createFakeMediaConstraints({
+    audio: false,
+    video: true,
+    frameRate: "99999",
+    resolution: "",
+    volume: "0",
+    aspectRatio: "",
+    resizeMode: "",
+  });
+  assert.equal(result.frameRate, 60);
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -468,9 +468,14 @@ export function createFakeMediaConstraints(
   parameters: CreateFakeMediaConstraintsParameters,
 ): FakeMediaStreamConstraints {
   const { audio, video, frameRate, resolution, volume, aspectRatio, resizeMode } = parameters;
-  // fake の default frameRate は 30 fps
+  // frameRate は URL パラメータ / UI のテキスト入力由来の string。
+  // 0 / 負数 / 0.5 / 0xN プレフィックスを素通しすると下流 worker の setTimeout が
+  // HTML Living Standard の "Timers" セクションにあるネストレベル clamp ルール
+  // (nesting level > 5 かつ timeout < 4 で 4 ms に揃える) によって 4 ms に丸められ、
+  // 実効 ~250 fps の過剰スケジューリングに陥るため、有限正数のみ受理して UI 上限 60 にクランプする。
+  // 本関数の戻り値 frameRate は常に [1, 60] の整数になる。
   const fps = Number.parseInt(frameRate, 10);
-  const parsedFrameRate = Number.isNaN(fps) ? 30 : fps;
+  const parsedFrameRate = Number.isFinite(fps) && fps > 0 ? Math.min(fps, 60) : 30;
   // width, height の default はそれぞれ 240 / 160
   const resolutionSize = getVideoSizeByResolution(resolution);
   const width = resolutionSize.width || 240;

--- a/src/workers/fakeVideo.worker.ts
+++ b/src/workers/fakeVideo.worker.ts
@@ -134,7 +134,15 @@ self.addEventListener("message", (event: MessageEvent<FakeVideoWorkerRequest>) =
 
       // フレームレートを設定
       if (data.frameRate !== undefined) {
-        ({ frameRate } = data);
+        // 二重防御: utils.ts 側で [1, 60] の整数にクランプ済みのため通常は素通しで足りるが、
+        // 将来 utils を経由しない別経路から呼ばれた場合や構造化クローン経由で
+        // NaN / Infinity / 負数 / 小数が紛れ込んだ場合に setTimeout の遅延計算が暴走しないよう、
+        // worker 側でも独立に検査する。
+        // Math.floor で先に整数化するのは 0.5 のような正の小数を一度 0 にして後段の > 0 判定で弾くため。
+        // Number.isFinite で Infinity / -Infinity / NaN を弾き、> 0 で 0 以下を弾く。
+        // どちらも満たさない値は 30 にフォールバックし、満たす値は上限 60 にクランプする。
+        const floored = Math.floor(data.frameRate);
+        frameRate = Number.isFinite(floored) && floored > 0 ? Math.min(floored, 60) : 30;
       }
 
       // channel_id を設定


### PR DESCRIPTION
## 概要

`createFakeMediaConstraints` の `parsedFrameRate` 算出が `Number.isNaN(fps) ? 30 : fps` で `NaN` だけ弾いており、`?frameRate=0` / `?frameRate=-1` / UI のテキスト入力 `0` / `-1` 等を素通ししていた。素通しされた `0` / 負数は下流の `fakeVideo.worker.ts` の `setTimeout` 遅延計算で 0 ms にクランプされ、HTML Living Standard の "Timers" セクションのネストレベル clamp ルール (nesting level > 5 かつ timeout < 4 で 4 ms に揃える) によって実効 ~250 fps の過剰スケジューリングに陥っていた。

## 変更内容

- `src/utils.ts` の `createFakeMediaConstraints` で `parsedFrameRate` を `Number.isFinite(fps) && fps > 0 ? Math.min(fps, 60) : 30` に厳格化し、戻り値 `frameRate` を常に `[1, 60]` の整数にする
- `src/workers/fakeVideo.worker.ts` の `init` ハンドラで `Math.floor` → `Number.isFinite && > 0` → `Math.min(_, 60)` を独立に実行し、構造化クローン経由で来た NaN / Infinity / 負数 / 小数を 30 にフォールバックして二重防御する
- `src/utils.test.ts` に `createFakeMediaConstraints` の境界値テスト 4 件 (`"0"` → 30 / `"1"` → 1 / `"60"` → 60 / `"99999"` → 60) を追加する
- `src/utils.prop.ts` に PBT 1 件を追加し、IEEE 754 端点・WebIDL long 全域・正常範囲 1..60・任意 string で戻り値が常に `[1, 60]` の整数になる不変条件を検証する

## 完了条件

- [x] `createFakeMediaConstraints` で frameRate を `[1, 60]` の整数にクランプする
- [x] `fakeVideo.worker.ts` でも二重防御する
- [x] CHANGES.md の `## develop` の `[FIX]` 末尾にエントリを追加する
- [x] 単体テスト 4 件 + PBT 1 件を追加し、既存テスト含めて全件 pass する

## 関連 issue

- issues/closed/0050-bug-fix-fake-video-worker-busy-loop.md