### PR TITLE
0051 createConnectOptions の parseMetadata 戻り値の型検証漏れを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -235,6 +235,10 @@
   - 0 / 負数 / 小数 / 16 進数表記は 30 にフォールバックし、60 超は 60 にクランプする
   - `fakeVideo.worker.ts` の `init` ハンドラでも `[1, 60]` にクランプして二重防御する
   - @voluntas
+- [FIX] `createConnectOptions` で `parseMetadata` 戻り値の型検証が漏れていた問題を修正する
+  - `videoVP9Params` / `videoAV1Params` / `videoH264Params` / `videoH265Params` / `signalingNotifyMetadata` は object（非 null・非 array）のみ受理する
+  - object 以外を SDK 経由でサーバに送って `connect.failed` を引き起こすのを防ぐ
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0051-bug-fix-forwarding-filters-undefined-cast.md
+++ b/issues/closed/0051-bug-fix-forwarding-filters-undefined-cast.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/fix-forwarding-filters-undefined-cast
 - Polished: 2026-06-16
@@ -332,3 +332,11 @@ CLAUDE.md「後方互換性は考慮しないこと」方針により、`?videoV
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 追加した単体テスト 8 件 + PBT 1 件が pass すること。
 - 既存テスト（`pnpm test`）および既存 Playwright e2e が通ること。
+
+## 解決方法
+
+- `src/utils.ts` に `isJsonObject` 型ガードを追加し、`parseMetadata` 戻り値が JSON object（非 null・非 array）であることを判定できるようにした。戻り値型 `Record<string, Json | undefined>` で narrow させて代入時の型安全を確保した。
+- `applyVideoCodecOptions` の `videoVP9Params` / `videoAV1Params` / `videoH264Params` / `videoH265Params` の 4 箇所、`applySignalingMetadataOptions` の `signalingNotifyMetadata` の計 5 箇所を `isJsonObject` 経由のガード代入に変更した。object 以外（`null` / `boolean` / `number` / `string` / `array`）は silent に未代入になり、SDK 経由で Sora サーバに送られて `connect.failed` を引き起こす経路を遮断した。
+- `src/utils.test.ts` に `createTestConnectionOptionsState` ヘルパー（`ConnectionOptionsState` 37 フィールドの defaults を返す）を追加し、`createConnectOptions` の単体テスト 8 件を追加した。VP9 の `"42"` / `"{\"a\":1}"` / `"null"` 各経路、AV1 / H264 / H265 の `"42"` smoke、`signalingNotifyMetadata` の `"null"` と `"{\"user\":\"x\"}"` を検証する。
+- `src/utils.prop.ts` から `createTestConnectionOptionsState` を utils.test.ts から import し、二重定義を避けた。PBT 1 件を追加して `videoVP9Params` と `signalingNotifyMetadata` の不変条件「結果は常に `undefined` または object（非 null・非 array）」を検証する。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追加した。

--- a/src/utils.prop.ts
+++ b/src/utils.prop.ts
@@ -24,7 +24,10 @@ import {
   VIDEO_CODEC_TYPES,
   VIDEO_CONTENT_HINTS,
 } from "./constants.ts";
+import type { ConnectionOptionsState } from "./types.ts";
+import { createTestConnectionOptionsState } from "./utils.test.ts";
 import {
+  createConnectOptions,
   createFakeMediaConstraints,
   formatUnixtime,
   getVideoSizeByResolution,
@@ -470,3 +473,30 @@ test.prop([
   assert.isAtLeast(result.frameRate, 1);
   assert.isAtMost(result.frameRate, 60);
 });
+
+// createConnectOptions の videoVP9Params / signalingNotifyMetadata 不変条件 PBT。
+// 任意の string と任意の valid JSON 文字列を混在生成し、結果が undefined または
+// object (非 null・非 array) のいずれかに収まることを保証する。
+// fc.oneof で fc.string() と fc.json() を混在させるのは、fc.string() 単独だと生成物の大半が
+// JSON.parse 失敗 → undefined ブランチに落ち、object 代入経路の不変条件を検証できないため。
+// videoAV1Params / videoH264Params / videoH265Params は VP9 と同コードパスのため省略する。
+test.prop([
+  fc.constantFrom("videoVP9Params" as const, "signalingNotifyMetadata" as const),
+  fc.oneof(fc.string(), fc.json()),
+])(
+  "createConnectOptions: videoVP9Params / signalingNotifyMetadata は常に undefined または object (非 null・非 array)",
+  (key, raw) => {
+    const overrides: Partial<ConnectionOptionsState> =
+      key === "videoVP9Params"
+        ? { enabledVideoVP9Params: true, videoVP9Params: raw }
+        : { enabledSignalingNotifyMetadata: true, signalingNotifyMetadata: raw };
+    const state = createTestConnectionOptionsState(overrides);
+    const result = createConnectOptions(state);
+    // result[key] の TypeScript 型は ConnectionOptions のフィールド型で正確に絞れないため
+    // unknown 経由で受けて typeof / Array.isArray で判定する
+    const value: unknown = result[key];
+    assert.isTrue(
+      value === undefined || (typeof value === "object" && value !== null && !Array.isArray(value)),
+    );
+  },
+);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -22,12 +22,63 @@ import {
   VIDEO_CODEC_TYPES,
   VIDEO_CONTENT_HINTS,
 } from "./constants.ts";
+import type { ConnectionOptionsState } from "./types.ts";
 import {
+  createConnectOptions,
   createFakeMediaConstraints,
   getValueByAspectRatio,
   parseMetadata,
   parseQueryString,
 } from "./utils.ts";
+
+// ConnectionOptionsState の完全な default を生成するヘルパー。
+// signals.ts の初期値をインポートしないのは、signals.ts 側の初期値変更がテストに直接波及するのを避けるため。
+// boolean / string / リテラル型は signals.ts と同じ既定値で書き下し、overrides で上書きできるようにする。
+// PBT 側 utils.prop.ts からも import して二重定義を避ける。
+export function createTestConnectionOptionsState(
+  overrides: Partial<ConnectionOptionsState> = {},
+): ConnectionOptionsState {
+  const defaults: ConnectionOptionsState = {
+    audio: true,
+    audioBitRate: "",
+    audioCodecType: "",
+    audioStreamingLanguageCode: "",
+    bundleId: "",
+    clientId: "",
+    dataChannelSignaling: "",
+    dataChannels: "",
+    enabledAudioStreamingLanguageCode: false,
+    enabledBundleId: false,
+    enabledClientId: false,
+    enabledDataChannel: false,
+    enabledSignalingNotifyMetadata: false,
+    enabledForwardingFilters: false,
+    enabledVideoVP9Params: false,
+    enabledVideoH264Params: false,
+    enabledVideoH265Params: false,
+    enabledVideoAV1Params: false,
+    ignoreDisconnectWebSocket: "",
+    signalingNotifyMetadata: "",
+    forwardingFilters: "",
+    simulcast: "",
+    simulcastRid: "",
+    simulcastRequestRid: "",
+    spotlight: "",
+    spotlightFocusRid: "",
+    spotlightNumber: "",
+    spotlightUnfocusRid: "",
+    video: true,
+    videoBitRate: "",
+    videoCodecType: "",
+    videoVP9Params: "",
+    videoH264Params: "",
+    videoH265Params: "",
+    videoAV1Params: "",
+    forceStereoOutput: false,
+    role: "sendrecv",
+  };
+  return { ...defaults, ...overrides };
+}
 
 // テスト用のヘルパー関数
 function createSearchParams(parameters: Record<string, unknown>): URLSearchParams {
@@ -319,4 +370,86 @@ test("createFakeMediaConstraints は frameRate に '99999' を渡すと parsedFr
     resizeMode: "",
   });
   assert.equal(result.frameRate, 60);
+});
+
+// createConnectOptions の parseMetadata 戻り値型検証テスト
+// videoXxxParams / signalingNotifyMetadata は object (非 null・非 array) のみ受理する責務を確認する
+test("createConnectOptions: videoVP9Params が '42' + enable=true なら未代入", () => {
+  // number が parseMetadata から返ってきても代入しないこと
+  const state = createTestConnectionOptionsState({
+    enabledVideoVP9Params: true,
+    videoVP9Params: "42",
+  });
+  const result = createConnectOptions(state);
+  assert.equal(result.videoVP9Params, undefined);
+});
+
+test("createConnectOptions: videoVP9Params が '{\"a\":1}' + enable=true なら object を代入 (正常系)", () => {
+  // object が parseMetadata から返ってきたらそのまま代入すること
+  const state = createTestConnectionOptionsState({
+    enabledVideoVP9Params: true,
+    videoVP9Params: '{"a":1}',
+  });
+  const result = createConnectOptions(state);
+  assert.deepEqual(result.videoVP9Params, { a: 1 });
+});
+
+test("createConnectOptions: videoVP9Params が 'null' + enable=true なら未代入", () => {
+  // null も object 判定で除外すること
+  const state = createTestConnectionOptionsState({
+    enabledVideoVP9Params: true,
+    videoVP9Params: "null",
+  });
+  const result = createConnectOptions(state);
+  assert.equal(result.videoVP9Params, undefined);
+});
+
+test("createConnectOptions: videoAV1Params が '42' + enable=true なら未代入", () => {
+  // AV1 が VP9 と同じ判定パスを通っていることを smoke で確認する
+  const state = createTestConnectionOptionsState({
+    enabledVideoAV1Params: true,
+    videoAV1Params: "42",
+  });
+  const result = createConnectOptions(state);
+  assert.equal(result.videoAV1Params, undefined);
+});
+
+test("createConnectOptions: videoH264Params が '42' + enable=true なら未代入", () => {
+  // H264 が VP9 と同じ判定パスを通っていることを smoke で確認する
+  const state = createTestConnectionOptionsState({
+    enabledVideoH264Params: true,
+    videoH264Params: "42",
+  });
+  const result = createConnectOptions(state);
+  assert.equal(result.videoH264Params, undefined);
+});
+
+test("createConnectOptions: videoH265Params が '42' + enable=true なら未代入", () => {
+  // H265 が VP9 と同じ判定パスを通っていることを smoke で確認する
+  const state = createTestConnectionOptionsState({
+    enabledVideoH265Params: true,
+    videoH265Params: "42",
+  });
+  const result = createConnectOptions(state);
+  assert.equal(result.videoH265Params, undefined);
+});
+
+test("createConnectOptions: signalingNotifyMetadata が 'null' + enable=true なら未代入", () => {
+  // signalingNotifyMetadata カテゴリでも null を除外すること
+  const state = createTestConnectionOptionsState({
+    enabledSignalingNotifyMetadata: true,
+    signalingNotifyMetadata: "null",
+  });
+  const result = createConnectOptions(state);
+  assert.equal(result.signalingNotifyMetadata, undefined);
+});
+
+test('createConnectOptions: signalingNotifyMetadata が \'{"user":"x"}\' + enable=true なら object を代入 (正常系)', () => {
+  // object が parseMetadata から返ってきたらそのまま代入すること
+  const state = createTestConnectionOptionsState({
+    enabledSignalingNotifyMetadata: true,
+    signalingNotifyMetadata: '{"user":"x"}',
+  });
+  const result = createConnectOptions(state);
+  assert.deepEqual(result.signalingNotifyMetadata, { user: "x" });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -667,6 +667,14 @@ export function parseMetadata(enabledMetadata: boolean, metadata: string): Json 
   }
 }
 
+// parseMetadata の戻り値が Sora 仕様で期待する JSON object (非 null・非 array) かを判定する。
+// typeof === "object" は null と array も真になるため明示的に除外する。
+// codec params (videoVP9Params / videoAV1Params / videoH264Params / videoH265Params) と
+// signalingNotifyMetadata の代入前ガードに利用する。
+export function isJsonObject(value: Json | undefined): value is Record<string, Json | undefined> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function getDefaultVideoCodecType(): (typeof VIDEO_CODEC_TYPES)[number] {
   // getCapabilities API が存在しない場合 (古いブラウザでは undefined になる)
   // oxlint-disable-next-line typescript/no-unnecessary-condition
@@ -783,16 +791,28 @@ function applyVideoCodecOptions(
     connectionOptions.videoBitRate = parsedVideoBitRate;
   }
   if (connectionOptionsState.enabledVideoVP9Params) {
-    connectionOptions.videoVP9Params = parseMetadata(true, connectionOptionsState.videoVP9Params);
+    const parsed = parseMetadata(true, connectionOptionsState.videoVP9Params);
+    if (isJsonObject(parsed)) {
+      connectionOptions.videoVP9Params = parsed;
+    }
   }
   if (connectionOptionsState.enabledVideoAV1Params) {
-    connectionOptions.videoAV1Params = parseMetadata(true, connectionOptionsState.videoAV1Params);
+    const parsed = parseMetadata(true, connectionOptionsState.videoAV1Params);
+    if (isJsonObject(parsed)) {
+      connectionOptions.videoAV1Params = parsed;
+    }
   }
   if (connectionOptionsState.enabledVideoH264Params) {
-    connectionOptions.videoH264Params = parseMetadata(true, connectionOptionsState.videoH264Params);
+    const parsed = parseMetadata(true, connectionOptionsState.videoH264Params);
+    if (isJsonObject(parsed)) {
+      connectionOptions.videoH264Params = parsed;
+    }
   }
   if (connectionOptionsState.enabledVideoH265Params) {
-    connectionOptions.videoH265Params = parseMetadata(true, connectionOptionsState.videoH265Params);
+    const parsed = parseMetadata(true, connectionOptionsState.videoH265Params);
+    if (isJsonObject(parsed)) {
+      connectionOptions.videoH265Params = parsed;
+    }
   }
 }
 
@@ -847,10 +867,10 @@ function applySignalingMetadataOptions(
   connectionOptionsState: ConnectionOptionsState,
 ): void {
   if (connectionOptionsState.enabledSignalingNotifyMetadata) {
-    connectionOptions.signalingNotifyMetadata = parseMetadata(
-      true,
-      connectionOptionsState.signalingNotifyMetadata,
-    );
+    const parsed = parseMetadata(true, connectionOptionsState.signalingNotifyMetadata);
+    if (isJsonObject(parsed)) {
+      connectionOptions.signalingNotifyMetadata = parsed;
+    }
   }
   if (connectionOptionsState.enabledForwardingFilters) {
     const parsedForwardingFilters = parseMetadata(true, connectionOptionsState.forwardingFilters);


### PR DESCRIPTION
## 概要

`createConnectOptions` の `applyVideoCodecOptions` と `applySignalingMetadataOptions` で `parseMetadata` の戻り値を型検証せずに `connectionOptions` に代入していたため、`null` / `boolean` / `number` / `string` / `array` が SDK のシグナリングペイロードにそのまま乗って Sora サーバ側で `connect.failed` を引き起こしていた。

## 変更内容

- `src/utils.ts` に `isJsonObject` 型ガードを追加し、`Record<string, Json | undefined>` で narrow させる
- `videoVP9Params` / `videoAV1Params` / `videoH264Params` / `videoH265Params` / `signalingNotifyMetadata` の 5 箇所で `isJsonObject` 経由のガード代入に変更し、object（非 null・非 array）以外は silent に未代入にする
- `src/utils.test.ts` に `createTestConnectionOptionsState` ヘルパーと境界値テスト 8 件を追加する
- `src/utils.prop.ts` に PBT 1 件を追加し、`videoVP9Params` と `signalingNotifyMetadata` の不変条件を検証する

## 完了条件

- [x] 5 箇所で object のみ受理するように厳格化する
- [x] CHANGES.md の \`## develop\` の \`[FIX]\` 末尾にエントリを追加する
- [x] 単体テスト 8 件 + PBT 1 件を追加し、既存テスト含めて全件 pass する

## 関連 issue

- issues/closed/0051-bug-fix-forwarding-filters-undefined-cast.md