### PR TITLE
0052 signalingUrlCandidates の URL クエリ経路で配列要素の型検証漏れを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -239,6 +239,10 @@
   - `videoVP9Params` / `videoAV1Params` / `videoH264Params` / `videoH265Params` / `signalingNotifyMetadata` は object（非 null・非 array）のみ受理する
   - object 以外を SDK 経由でサーバに送って `connect.failed` を引き起こすのを防ぐ
   - @voluntas
+- [FIX] `signalingUrlCandidates` の URL クエリ経路で配列要素の型検証が漏れていた問題を修正する
+  - `parseQueryString` で `Array.isArray` に加えて `every((item) => typeof item === "string")` を要求する
+  - 不正要素を含む場合は `undefined` に落とし、SDK 側 `new WebSocket(_)` の `SyntaxError` を回避する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0052-bug-fix-signaling-url-candidates-validation.md
+++ b/issues/closed/0052-bug-fix-signaling-url-candidates-validation.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/fix-signaling-url-candidates-validation
 - Polished: 2026-06-16
@@ -278,3 +278,11 @@ test.prop([signalingUrlCandidatesWithInvalidArb])(
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 追加した単体テスト 6 件 + PBT 1 件が pass すること。
 - 既存テスト（`pnpm test`）および既存 Playwright e2e が通ること。
+
+## 解決方法
+
+- `src/utils.ts` に `isStringArray` 型ガード関数（`value is string[]`）を `parseQueryString` の直前に追加し、`Array.isArray` に加えて要素の `typeof === "string"` も検証する。0051 で追加した `isJsonObject` と同じく `export` してプロジェクト内の再利用に備える。
+- `parseQueryString` 内の `signalingUrlCandidates` 代入部で `Array.isArray(_)` を `isStringArray(_)` に置き換え、非 string 要素を含む配列は `undefined` に落ちるようにした。`?signalingUrlCandidates=[1,2,3]` などの不正値が SDK 内部の `new WebSocket(_)` で `SyntaxError` を起こす経路を境界で遮断した。
+- `src/utils.test.ts` に異常系 5 件（全 number / 全 null / 全 boolean / 全 object / 混在）と空配列の回帰防止 1 件を追加した。
+- `src/utils.prop.ts` に `signalingUrlCandidatesWithInvalidArb` を追加し、`fc.oneof` で webUrl / integer / null / boolean / jsonValue / string を混在生成して PBT 1 件「結果は常に undefined または string[]」を検証する。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追加した。

--- a/src/utils.prop.ts
+++ b/src/utils.prop.ts
@@ -88,6 +88,16 @@ const blurRadiusArb = fc.constantFrom(...BLUR_RADIUS);
 // signalingUrlCandidates 用の文字列配列の Arbitrary
 const signalingUrlCandidatesArb = fc.array(fc.webUrl());
 
+// signalingUrlCandidates の異常系検証用 Arbitrary。
+// 文字列 / 整数 / null / boolean / JSON 値を fc.oneof で混在させ、要素型検証が常に [string[] | undefined] を返すことを保証する。
+// fc.anything() は BigInt / Function / 循環参照を含み JSON.stringify が TypeError を投げるため利用せず、fc.jsonValue() を採用する。
+// fc.integer() / fc.constant(null) / fc.boolean() / fc.string() は fc.jsonValue() に包含されるが、shrink 時に代表値を明示的に踏ませるため別個に列挙する。
+// 空配列入力は単体テスト側でカバーするため minLength: 1 で除外する。
+const signalingUrlCandidatesWithInvalidArb = fc.array(
+  fc.oneof(fc.webUrl(), fc.integer(), fc.constant(null), fc.boolean(), fc.jsonValue(), fc.string()),
+  { minLength: 1 },
+);
+
 // 解像度の Arbitrary（形式: "幅 x 高さ"）
 const resolutionArb = fc
   .tuple(fc.integer({ min: 1, max: 3840 }), fc.integer({ min: 1, max: 2160 }))
@@ -278,6 +288,24 @@ test.prop([fc.array(fc.webUrl(), { minLength: 1, maxLength: 5 })])(
     const result = parseQueryString(searchParams);
 
     assert.deepEqual(result.signalingUrlCandidates, candidates);
+  },
+);
+
+// signalingUrlCandidates の要素型検証 PBT。
+// 正常 / 異常 のどちらの配列でも結果が undefined または string[] のいずれかに収まることを保証する。
+// 異常系入力が undefined に落ちる具体的なホワイトリスト確認は単体テスト 5 件 (number / null / boolean / object / 混在) と
+// 空配列回帰防止 1 件でカバーする。
+test.prop([signalingUrlCandidatesWithInvalidArb])(
+  "signalingUrlCandidates のパース結果は常に undefined または string[] になる",
+  (arr) => {
+    const searchParams = new URLSearchParams();
+    searchParams.set("signalingUrlCandidates", JSON.stringify(arr));
+    const result = parseQueryString(searchParams);
+    const value = result.signalingUrlCandidates;
+    assert.isTrue(
+      value === undefined ||
+        (Array.isArray(value) && value.every((item) => typeof item === "string")),
+    );
   },
 );
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -213,6 +213,51 @@ test("signalingUrlCandidates が配列でない場合は undefined になる", (
   assert.deepEqual(result, {});
 });
 
+// signalingUrlCandidates の要素型検証テスト
+// 非 string 要素は SDK 内部の new WebSocket(_) で SyntaxError を引き起こすため、境界で undefined に落とす
+test("signalingUrlCandidates の要素が全て number の場合は undefined になる", () => {
+  const searchParams = new URLSearchParams();
+  searchParams.set("signalingUrlCandidates", JSON.stringify([1, 2, 3]));
+  const result = parseQueryString(searchParams);
+  assert.equal(result.signalingUrlCandidates, undefined);
+});
+
+test("signalingUrlCandidates の要素が全て null の場合は undefined になる", () => {
+  const searchParams = new URLSearchParams();
+  searchParams.set("signalingUrlCandidates", JSON.stringify([null, null]));
+  const result = parseQueryString(searchParams);
+  assert.equal(result.signalingUrlCandidates, undefined);
+});
+
+test("signalingUrlCandidates の要素が全て boolean の場合は undefined になる", () => {
+  const searchParams = new URLSearchParams();
+  searchParams.set("signalingUrlCandidates", JSON.stringify([true, false]));
+  const result = parseQueryString(searchParams);
+  assert.equal(result.signalingUrlCandidates, undefined);
+});
+
+test("signalingUrlCandidates の要素が全て object の場合は undefined になる", () => {
+  const searchParams = new URLSearchParams();
+  searchParams.set("signalingUrlCandidates", JSON.stringify([{ url: "wss://x" }]));
+  const result = parseQueryString(searchParams);
+  assert.equal(result.signalingUrlCandidates, undefined);
+});
+
+test("signalingUrlCandidates に文字列と非文字列が混在する配列は undefined になる", () => {
+  const searchParams = new URLSearchParams();
+  searchParams.set("signalingUrlCandidates", JSON.stringify(["wss://example.com/signaling", 1]));
+  const result = parseQueryString(searchParams);
+  assert.equal(result.signalingUrlCandidates, undefined);
+});
+
+test("signalingUrlCandidates が空配列 [] の場合は空配列として受理される（既存挙動の回帰防止）", () => {
+  // every は空配列で true を返すため、空配列は型ガードを通過して維持される
+  const searchParams = new URLSearchParams();
+  searchParams.set("signalingUrlCandidates", JSON.stringify([]));
+  const result = parseQueryString(searchParams);
+  assert.deepEqual(result.signalingUrlCandidates, []);
+});
+
 test("undefined の項目は削除される", () => {
   const searchParams = createSearchParams({
     channelId: "test-channel",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,6 +86,14 @@ function parseStringParameter(searchParams: URLSearchParams, key: string): strin
   return undefined;
 }
 
+// 配列性 + 要素 string 性を両方検証する型ガード関数。
+// 要素に number / null / boolean / object が混在すると SDK 内部の new WebSocket(_) が
+// USVString 変換後 URL パースに失敗して SyntaxError (DOMException) を投げるため、境界で undefined に落とす。
+// every は空配列で true を返すため `[]` は受理されるが、空配列が下流の SDK に届かない保証は呼び出し側のガードに委ねる。
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
 // クエリ文字列パーサー
 export function parseQueryString(searchParams: URLSearchParams): Partial<QueryStringParameters> {
   // URLSearchParams から値を取得して boolean | undefined を返す
@@ -169,7 +177,7 @@ export function parseQueryString(searchParams: URLSearchParams): Partial<QuerySt
     metadata: parseStringParameter(searchParams, "metadata"),
     showStats: parseBooleanParameter(searchParams, "showStats"),
     signalingNotifyMetadata: parseStringParameter(searchParams, "signalingNotifyMetadata"),
-    signalingUrlCandidates: Array.isArray(signalingUrlCandidates)
+    signalingUrlCandidates: isStringArray(signalingUrlCandidates)
       ? signalingUrlCandidates
       : undefined,
     forwardingFilters: parseStringParameter(searchParams, "forwardingFilters"),


### PR DESCRIPTION
## 概要

`parseQueryString` で `signalingUrlCandidates` を `Array.isArray` のみで検証しており、`?signalingUrlCandidates=[1,2,3]` のような非 string 要素が SDK の `new WebSocket(_)` に到達して `SyntaxError` を起こしていた。境界で要素の `typeof === "string"` も検証する。

## 変更内容

- `src/utils.ts` に `isStringArray` 型ガード関数を追加し、`parseQueryString` で利用する
- 不正要素を含む配列は `undefined` に落ち、`?signalingUrlCandidates=[1,2,3]` などが SDK に届かなくなる
- 空配列 `[]` は既存挙動どおり受理する（既存ガードで SDK には届かない）
- `src/utils.test.ts` に異常系 5 件と空配列の回帰防止 1 件を追加する
- `src/utils.prop.ts` に PBT 1 件を追加し、結果が常に `undefined` または `string[]` であることを検証する

## 完了条件

- [x] `isStringArray` 型ガードを導入し、要素の `typeof === "string"` を検証する
- [x] CHANGES.md の \`## develop\` の \`[FIX]\` 末尾にエントリを追加する
- [x] 単体テスト 6 件 + PBT 1 件を追加し、既存テスト含めて全件 pass する

## 関連 issue

- issues/closed/0052-bug-fix-signaling-url-candidates-validation.md