### PR TITLE
0059 loadUrlEntries の OPFS 読み込みで要素の型検証漏れを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -243,6 +243,10 @@
   - `parseQueryString` で `Array.isArray` に加えて `every((item) => typeof item === "string")` を要求する
   - 不正要素を含む場合は `undefined` に落とし、SDK 側 `new WebSocket(_)` の `SyntaxError` を回避する
   - @voluntas
+- [FIX] `loadUrlEntries` の OPFS 読み込みで要素の型検証が漏れていた問題を修正する
+  - `{ url: string; enabled: boolean }` の構造を `every` で検証し、不正な要素を含む場合は空配列を返す
+  - `JSON.parse` + 型検証を `parseUrlEntriesFromText` に切り出してユニットテスト可能にする
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0059-bug-fix-load-url-entries-element-validation.md
+++ b/issues/closed/0059-bug-fix-load-url-entries-element-validation.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/fix-load-url-entries-element-validation
 - Polished: 2026-06-16
@@ -348,3 +348,12 @@ test.prop([fc.string()])(
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 追加したユニットテスト 8 件 + PBT 2 件が pass すること。
 - 既存テスト（`pnpm test`）および既存 Playwright e2e が pass すること。
+
+## 解決方法
+
+- `src/opfs.ts` に `isUrlEntry` 型ガード関数（`value is UrlEntry`）を追加し、`url: string` と `enabled: boolean` の構造を実行時に検証できるようにした。0051/0052 で追加した `isJsonObject` / `isStringArray` と並列に `export` する。
+- `parseUrlEntriesFromText` を新規追加し、`JSON.parse` + ルートオブジェクト形状検証 + `every(isUrlEntry)` で `UrlEntry[]` を返す純粋関数として切り出した。不正な要素が 1 件でもあれば全体を空配列に落とす（部分救済しない）。
+- `loadUrlEntries` を薄いラッパーに変更し、`parseUrlEntriesFromText` を呼ぶ形にした。`catch` ブロックのコメントを「OPFS API 呼び出しの例外を握りつぶす」に更新した（パースエラーは parser 内で吸収済み）。
+- `src/opfs.test.ts` を新規作成し、ユニットテスト 10 件（異常系 7 件 + null 要素 + 正常/不正混在 + 回帰防止 1 件）を追加した。
+- `src/opfs.prop.ts` を新規作成し、PBT 2 件（任意入力で例外を投げない / 戻り値が常に `UrlEntry[]` の形状）を追加した。入力 Arbitrary は `fc.oneof(fc.string(), fc.json())` で JSON.parse 失敗と構造検証の両ブランチを踏ませる。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追加した。

--- a/src/opfs.prop.ts
+++ b/src/opfs.prop.ts
@@ -1,0 +1,35 @@
+import { fc, test } from "@fast-check/vitest";
+import { assert } from "vite-plus/test";
+
+import { parseUrlEntriesFromText } from "./opfs.ts";
+
+// parseUrlEntriesFromText の入力 Arbitrary。
+// 任意 string と valid JSON 文字列を fc.oneof で混在させて、JSON.parse 失敗ブランチと
+// 構造検証ブランチの両方を踏ませる。fc.string() 単独だと大半が JSON.parse 失敗で
+// 早期 return に落ち、要素検証ロジックの不変条件を踏み込めないため fc.json() を混ぜる。
+const parseInputArb = fc.oneof(fc.string(), fc.json());
+
+// parseUrlEntriesFromText の不変条件 PBT。
+// 任意の文字列入力に対して例外を投げず、戻り値が常に UrlEntry[] の形状を持つことを保証する。
+test.prop([parseInputArb])("parseUrlEntriesFromText は任意の文字列入力で例外を投げない", (text) => {
+  parseUrlEntriesFromText(text);
+});
+
+test.prop([parseInputArb])(
+  "parseUrlEntriesFromText の戻り値は常に UrlEntry[] の形状を持つ",
+  (text) => {
+    // 戻り値型 UrlEntry[] を unknown 経由で受けて narrow を解除し、実行時形状を再検査する。
+    // 戻り値型のまま entry.url / entry.enabled を typeof で検査すると型情報そのままのトートロジーになり、
+    // 「実装が as UrlEntry[] 等で型を偽装したまま実行時形状が崩れた場合」を捕捉できない。
+    const result: unknown = parseUrlEntriesFromText(text);
+    assert.isTrue(Array.isArray(result));
+    if (!Array.isArray(result)) {
+      return;
+    }
+    for (const entry of result) {
+      assert.isTrue(typeof entry === "object" && entry !== null);
+      assert.isTrue(typeof (entry as { url?: unknown }).url === "string");
+      assert.isTrue(typeof (entry as { enabled?: unknown }).enabled === "boolean");
+    }
+  },
+);

--- a/src/opfs.test.ts
+++ b/src/opfs.test.ts
@@ -1,0 +1,71 @@
+import { assert, test } from "vite-plus/test";
+
+import { parseUrlEntriesFromText } from "./opfs.ts";
+
+// parseUrlEntriesFromText の異常系・回帰防止テスト
+// OPFS ファイルが壊れている / 不正な要素を含む場合に空配列を返し、SDK 経路に不正値が流れないことを確認する
+test("parseUrlEntriesFromText は invalid JSON 文字列を渡されたとき空配列を返す", () => {
+  // JSON.parse 例外は catch で空配列に落とす
+  assert.deepEqual(parseUrlEntriesFromText("{invalid}"), []);
+});
+
+test("parseUrlEntriesFromText は urlEntries が無い JSON を渡されたとき空配列を返す", () => {
+  // urlEntries キー欠落は in 演算子で false になるので空配列
+  assert.deepEqual(parseUrlEntriesFromText("{}"), []);
+});
+
+test("parseUrlEntriesFromText は urlEntries が空配列の JSON を渡されたとき空配列を返す", () => {
+  // every は空配列で true を返すため受理されるが、結果としては空配列のまま
+  assert.deepEqual(parseUrlEntriesFromText('{"urlEntries":[]}'), []);
+});
+
+test("parseUrlEntriesFromText は urlEntries が null の JSON を渡されたとき空配列を返す", () => {
+  // null は Array.isArray で false
+  assert.deepEqual(parseUrlEntriesFromText('{"urlEntries":null}'), []);
+});
+
+test("parseUrlEntriesFromText は url が number の要素を含む JSON を渡されたとき空配列を返す", () => {
+  // url が string でなければ全体破棄 (本丸: number を URL として扱う経路を遮断)
+  assert.deepEqual(parseUrlEntriesFromText('{"urlEntries":[{"url":42,"enabled":true}]}'), []);
+});
+
+test("parseUrlEntriesFromText は enabled が string の要素を含む JSON を渡されたとき空配列を返す", () => {
+  // enabled が boolean でなければ全体破棄
+  assert.deepEqual(
+    parseUrlEntriesFromText('{"urlEntries":[{"url":"wss://x","enabled":"yes"}]}'),
+    [],
+  );
+});
+
+test("parseUrlEntriesFromText は enabled が欠落した要素を含む JSON を渡されたとき空配列を返す", () => {
+  // 必須フィールド欠落は in 演算子で false になるので全体破棄
+  assert.deepEqual(parseUrlEntriesFromText('{"urlEntries":[{"url":"wss://x"}]}'), []);
+});
+
+test("parseUrlEntriesFromText は null 要素を含む JSON を渡されたとき空配列を返す", () => {
+  // null は typeof === "object" を満たすが !== null で弾かれる
+  assert.deepEqual(parseUrlEntriesFromText('{"urlEntries":[null]}'), []);
+});
+
+test("parseUrlEntriesFromText は正常要素と不正要素が混在する JSON を渡されたとき空配列を返す", () => {
+  // 1 件でも不正なら全体破棄 (部分救済しない)
+  assert.deepEqual(
+    parseUrlEntriesFromText(
+      '{"urlEntries":[{"url":"wss://valid","enabled":true},{"url":42,"enabled":true}]}',
+    ),
+    [],
+  );
+});
+
+test("parseUrlEntriesFromText は正常な要素のみの JSON を渡されたとき要素配列を返す（既存挙動の回帰防止）", () => {
+  // 正常な配列は受理して同形の配列を返す
+  assert.deepEqual(
+    parseUrlEntriesFromText(
+      '{"urlEntries":[{"url":"wss://a","enabled":true},{"url":"wss://b","enabled":false}]}',
+    ),
+    [
+      { url: "wss://a", enabled: true },
+      { url: "wss://b", enabled: false },
+    ],
+  );
+});

--- a/src/opfs.ts
+++ b/src/opfs.ts
@@ -14,6 +14,44 @@ export interface SignalingUrlCandidatesSettings {
   urlEntries: UrlEntry[];
 }
 
+// UrlEntry の構造 ({ url: string; enabled: boolean }) を実行時に検証する型ガード。
+// JSON.parse 経由で取得した任意形状の値に対し、url が string・enabled が boolean であることを確認する。
+export function isUrlEntry(value: unknown): value is UrlEntry {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "url" in value &&
+    typeof value.url === "string" &&
+    "enabled" in value &&
+    typeof value.enabled === "boolean"
+  );
+}
+
+// OPFS から読んだテキストを UrlEntry[] にパース・検証する純粋関数。
+// JSON.parse の戻り値は実行時には任意の形状を取り得るため、SignalingUrlCandidatesSettings キャストは
+// 型上の偽装に過ぎない。urlEntries の各要素の url / enabled 構造を isUrlEntry で実行時に検証し、
+// 不正な要素を 1 つでも含む場合は全体を空配列に落とす。
+// 部分救済しない理由は、ユーザーが「自分の登録した URL が消えた」状態を SignalingUrlModal の
+// 未登録状態として明確に観測できるようにするため。
+export function parseUrlEntriesFromText(text: string): UrlEntry[] {
+  let settings: unknown;
+  try {
+    settings = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  if (
+    typeof settings === "object" &&
+    settings !== null &&
+    "urlEntries" in settings &&
+    Array.isArray(settings.urlEntries) &&
+    settings.urlEntries.every(isUrlEntry)
+  ) {
+    return settings.urlEntries;
+  }
+  return [];
+}
+
 // OPFS から URL エントリを読み込む
 export async function loadUrlEntries(): Promise<UrlEntry[]> {
   try {
@@ -27,15 +65,10 @@ export async function loadUrlEntries(): Promise<UrlEntry[]> {
     const fileHandle = await root.getFileHandle(SETTINGS_FILE_NAME, { create: false });
     const file = await fileHandle.getFile();
     const text = await file.text();
-    const settings = JSON.parse(text) as SignalingUrlCandidatesSettings;
-
-    if (Array.isArray(settings.urlEntries)) {
-      return settings.urlEntries;
-    }
-
-    return [];
+    return parseUrlEntriesFromText(text);
   } catch {
-    // ファイルが存在しない場合やパースエラーの場合は空配列を返す
+    // OPFS API 呼び出しでファイルが存在しない / ハンドル取得失敗等の例外を握りつぶす
+    // (パースエラーは parseUrlEntriesFromText 内で吸収済み)
     return [];
   }
 }


### PR DESCRIPTION
## 概要

`loadUrlEntries` (`src/opfs.ts`) が `JSON.parse` 後に `Array.isArray` のみで配列性を確認し、要素 `{ url: string; enabled: boolean }` の構造を検証していなかった。OPFS ファイルが壊れていたり別バージョンで保存されたスキーマと衝突した場合に、不正要素が下流まで到達し SDK で `SyntaxError` を引き起こす。0052 (URL クエリ経路) と対になる OPFS 経路の境界バリデーション。

## 変更内容

- `src/opfs.ts` に `isUrlEntry` 型ガード関数を追加し、`url` / `enabled` の構造を実行時に検証する
- `parseUrlEntriesFromText` を切り出して `JSON.parse` + 型検証を純粋関数化し、ユニットテスト可能にする
- 不正要素を 1 件でも含む場合は全体を空配列に落とす（部分救済しない）
- `src/opfs.test.ts` を新規作成し、異常系 7 件 + null 要素 + 正常/不正混在 + 回帰防止 1 件の計 10 件を追加する
- `src/opfs.prop.ts` を新規作成し、`fc.oneof(fc.string(), fc.json())` で PBT 2 件（任意入力で例外を投げない / 戻り値が常に `UrlEntry[]` の形状）を追加する

## 完了条件

- [x] `loadUrlEntries` の戻り値が `{ url: string; enabled: boolean }[]` であることを実行時保証する
- [x] 不正要素を含む場合は空配列を返す（混在ケース含めて全体破棄）
- [x] `parseUrlEntriesFromText` を export してユニットテスト可能にする
- [x] CHANGES.md の \`## develop\` の \`[FIX]\` 末尾にエントリを追加する
- [x] ユニットテスト 10 件 + PBT 2 件を追加し、既存テスト含めて全件 pass する

## 関連 issue

- issues/closed/0059-bug-fix-load-url-entries-element-validation.md
- issues/closed/0052-bug-fix-signaling-url-candidates-validation.md (URL クエリ経路の同種検証)