### PR TITLE
0053 RequestMediaButton / DisposeMediaButton の disabled に localMediaStream の状態を反映する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -247,6 +247,10 @@
   - `{ url: string; enabled: boolean }` の構造を `every` で検証し、不正な要素を含む場合は空配列を返す
   - `JSON.parse` + 型検証を `parseUrlEntriesFromText` に切り出してユニットテスト可能にする
   - @voluntas
+- [FIX] `RequestMediaButton` / `DisposeMediaButton` の `disabled` 条件に `localMediaStream` の状態を反映する
+  - `RequestMediaButton` は `localMediaStream` が取得済みのとき無効化し、重複した `getUserMedia` 呼び出しによる権限プロンプト再表示を防ぐ
+  - `DisposeMediaButton` は `localMediaStream` が null のとき無効化し、無意味な空打ちを防ぐ
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0053-bug-fix-request-media-button-disabled.md
+++ b/issues/closed/0053-bug-fix-request-media-button-disabled.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/fix-request-media-button-disabled
 - Polished: 2026-06-16
@@ -233,3 +233,11 @@ closed/0033 で同じ「`MediaStream` 系を要するロジックは jsdom + モ
 - 状態遷移マトリクスの「修正」セルすべてが期待通り disable になること。
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 既存テスト（`pnpm test`）および既存 Playwright e2e が pass すること。
+
+## 解決方法
+
+- `src/components/DevtoolsPane/RequestMediaButton.tsx` の `disabled` 式に `localMediaStream.value !== null` を追加し、メディア取得済みのときボタンを無効化した。重複した `getUserMedia` 呼び出しによる権限プロンプト再表示や processor の不本意停止を防ぐ。
+- `src/components/DevtoolsPane/DisposeMediaButton.tsx` の `disabled` 式に `localMediaStream.value === null` を追加し、破棄対象が無いときボタンを無効化した。無意味な空打ちと付随する副作用（`closeFakeContentsAudio` / worker stop など）を防ぐ。
+- 両ボタンの `import` に `localMediaStream` を追加し、各 disabled 条件の意図をコメントで明示した。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追加した。
+- テスト追加なし（`MediaStream` を jsdom で生成不可かつモック禁止規約のため）。状態遷移マトリクスは手動検証で網羅する。

--- a/src/components/DevtoolsPane/DisposeMediaButton.tsx
+++ b/src/components/DevtoolsPane/DisposeMediaButton.tsx
@@ -1,12 +1,20 @@
 import { disposeMedia } from "@/app/actions";
-import { isFormDisabled, role, sora } from "@/app/signals";
+import { isFormDisabled, localMediaStream, role, sora } from "@/app/signals";
 import { Button } from "@/components/ui";
 
 export function DisposeMediaButton() {
   const onClick = (): void => {
     void disposeMedia();
   };
-  const disabled = role.value === "recvonly" || sora.value !== null || isFormDisabled.value;
+  // recvonly: localMediaStream を持たない
+  // sora !== null: 接続中は dispose せず disconnectSora 経由でクリーンアップ
+  // localMediaStream === null: そもそも dispose 対象が無い
+  // isFormDisabled: connecting / preparing / connected の同期防止
+  const disabled =
+    role.value === "recvonly" ||
+    sora.value !== null ||
+    localMediaStream.value === null ||
+    isFormDisabled.value;
   return (
     <div className="col-auto mb-1">
       <Button variant="outline-secondary" onClick={onClick} disabled={disabled}>

--- a/src/components/DevtoolsPane/RequestMediaButton.tsx
+++ b/src/components/DevtoolsPane/RequestMediaButton.tsx
@@ -1,12 +1,20 @@
 import { requestMedia } from "@/app/actions";
-import { isFormDisabled, role, sora } from "@/app/signals";
+import { isFormDisabled, localMediaStream, role, sora } from "@/app/signals";
 import { Button } from "@/components/ui";
 
 export function RequestMediaButton() {
   const onClick = (): void => {
     void requestMedia();
   };
-  const disabled = role.value === "recvonly" || sora.value !== null || isFormDisabled.value;
+  // recvonly: 送信メディア不要なので request 不要
+  // sora !== null: 接続済みは UpdateMediaStreamButton で更新するため request 不要
+  // localMediaStream !== null: 既に取得済みなので重複取得を防ぐ
+  // isFormDisabled: connecting / preparing / connected の同期防止
+  const disabled =
+    role.value === "recvonly" ||
+    sora.value !== null ||
+    localMediaStream.value !== null ||
+    isFormDisabled.value;
   return (
     <div className="col-auto mb-1">
       <Button variant="outline-secondary" onClick={onClick} disabled={disabled}>


### PR DESCRIPTION
## 概要

`RequestMediaButton` と `DisposeMediaButton` の `disabled` 条件がコピペ流用されており、`localMediaStream` の有無を反映していなかった。重複した `getUserMedia` 呼び出しによる権限プロンプト再表示や、`disposeMedia` の空打ちによる processor 不本意停止が起こりうる。

## 変更内容

- `RequestMediaButton.tsx` の `disabled` 式に `localMediaStream.value !== null` を追加する
- `DisposeMediaButton.tsx` の `disabled` 式に `localMediaStream.value === null` を追加する
- 両ボタンの各 disabled 条件にコメントで意図を明記する

## 完了条件

- [x] RequestMediaButton: 取得済みのとき disable
- [x] DisposeMediaButton: localMediaStream が null のとき disable
- [x] recvonly / 接続中の既存挙動を維持
- [x] CHANGES.md の \`## develop\` の \`[FIX]\` 末尾にエントリを追加する

## 関連 issue

- issues/closed/0053-bug-fix-request-media-button-disabled.md