### PR TITLE
0054 UpdateMediaStreamButton の disabled と updateMediaStream の in-flight ガードを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -251,6 +251,10 @@
   - `RequestMediaButton` は `localMediaStream` が取得済みのとき無効化し、重複した `getUserMedia` 呼び出しによる権限プロンプト再表示を防ぐ
   - `DisposeMediaButton` は `localMediaStream` が null のとき無効化し、無意味な空打ちを防ぐ
   - @voluntas
+- [FIX] `UpdateMediaStreamButton` の `disabled` と `updateMediaStream` の in-flight ガードを追加する
+  - `updateMediaStream` をモジュールローカルな in-flight Promise でガードし、連打 / `AudioInputForm` / `VideoInputForm` の onChange と重なっても同時に複数走らないようにする
+  - `UpdateMediaStreamButton` の `disabled` に `localMediaStream === null` および `preparing` / `connecting` / `disconnecting` の過渡状態を反映し、対象が無い / 過渡状態での押下を防ぐ（`connected` 中はデバイス切替が主用途のため enable のまま）
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0054-bug-fix-update-media-stream-button-disabled.md
+++ b/issues/closed/0054-bug-fix-update-media-stream-button-disabled.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/fix-update-media-stream-button-disabled
 
@@ -342,3 +342,12 @@ export function UpdateMediaStreamButton() {
 - fakeMedia 経路で `AudioContext` の重複生成が起きないこと ( DevTools Memory タブの heap snapshot で `BaseAudioContext` インスタンス数が連打回数によらず 1 のままであること)。
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 既存テスト ( `pnpm test` ) および既存 Playwright e2e が pass すること。
+
+## 解決方法
+
+- `src/app/actions.ts` の `updateMediaStream` 本体を `updateMediaStreamImpl` にリネーム（`export` を外す）し、0045 で追加された中断検出ガードもそのまま内部に保持した。
+- 同ファイルにモジュールローカルな in-flight Promise `updateMediaStreamInFlight` を宣言し、新しい `export const updateMediaStream = async (): Promise<void> => { ... }` の wrapper を追加した。0048 の `reconnectSora` と同形で、後発呼び出しは既存の in-flight Promise を返し、`try/finally` で確実に null に戻す。
+- `src/components/DevtoolsPane/UpdateMediaStreamButton.tsx` の `<Button>` に `disabled` を追加した。`localMediaStream === null`、`preparing` / `connecting` / `disconnecting` の過渡状態で無効化し、`connected` 中はデバイス切替が主用途のため enable のまま保つ。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追加した。
+- caller (`UpdateMediaStreamButton` / `AudioInputForm` / `VideoInputForm`) はインターフェース互換のため無変更。
+- テスト追加なし（`MediaStream` を jsdom で生成不可かつモック禁止規約のため）。状態遷移マトリクスと連打レースは手動検証で網羅する。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1849,8 +1849,9 @@ export const unregisterServiceWorker = async (): Promise<void> => {
   }
 };
 
-// デバイスの変更時などに Sora との接続を維持したまま MediaStream のみ更新
-export const updateMediaStream = async (): Promise<void> => {
+// updateMediaStream の本体実装。in-flight ガードはこの関数の外側 wrapper で行う。
+// デバイスの変更時などに Sora との接続を維持したまま MediaStream のみ更新する。
+const updateMediaStreamImpl = async (): Promise<void> => {
   const state = getStateForMediaStream();
   const localMediaStreamValue = signals.localMediaStream.value;
   const soraValue = signals.sora.value;
@@ -1933,6 +1934,25 @@ export const updateMediaStream = async (): Promise<void> => {
   }
   signals.setLocalMediaStream(mediaStream);
   signals.setFakeContentsAudio(audioContext, gainNode);
+};
+
+// updateMediaStream の二重起動を防ぐためのモジュールローカルな in-flight Promise。
+// UpdateMediaStreamButton 連打と AudioInputForm / VideoInputForm の onChange が並列発火しても
+// 後発は既存の in-flight Promise を共有し、updateMediaStreamImpl の signal 上書きと
+// AudioContext 重複生成を防ぐ。Promise は finally で確実に null に戻す。
+let updateMediaStreamInFlight: Promise<void> | null = null;
+export const updateMediaStream = async (): Promise<void> => {
+  if (updateMediaStreamInFlight) {
+    return updateMediaStreamInFlight;
+  }
+  updateMediaStreamInFlight = (async () => {
+    try {
+      await updateMediaStreamImpl();
+    } finally {
+      updateMediaStreamInFlight = null;
+    }
+  })();
+  return updateMediaStreamInFlight;
 };
 
 export const setMicDeviceAction = async (micDevice: boolean): Promise<void> => {

--- a/src/components/DevtoolsPane/UpdateMediaStreamButton.tsx
+++ b/src/components/DevtoolsPane/UpdateMediaStreamButton.tsx
@@ -1,13 +1,23 @@
 import { updateMediaStream } from "@/app/actions";
+import { connectionStatus, localMediaStream } from "@/app/signals";
 import { Button } from "@/components/ui";
 
 export function UpdateMediaStreamButton() {
   const onClick = (): void => {
     void updateMediaStream();
   };
+  // localMediaStream === null: そもそも更新対象が無い (updateMediaStream 冒頭で早期 return される無意味な呼び出し)
+  // preparing / connecting / disconnecting: 過渡状態でメディア更新するとレースを誘発する
+  // connected は disable しない: 本関数の主用途は接続中のデバイス切替
+  const status = connectionStatus.value;
+  const disabled =
+    localMediaStream.value === null ||
+    status === "preparing" ||
+    status === "connecting" ||
+    status === "disconnecting";
   return (
     <div className="col-auto mb-1">
-      <Button variant="outline-secondary" onClick={onClick}>
+      <Button variant="outline-secondary" onClick={onClick} disabled={disabled}>
         update-mediastream
       </Button>
     </div>


### PR DESCRIPTION
## 概要

`UpdateMediaStreamButton` は `disabled` を持たず常に押せて、関数 `updateMediaStream` には in-flight ガードがない。`UpdateMediaStreamButton` 連打 / `AudioInputForm` / `VideoInputForm` の onChange の 3 経路から並列に起動されると `setLocalMediaStream` の旧 stream stop による先発・後発の競合と AudioContext 重複生成が起きる。

## 変更内容

- `updateMediaStream` 本体を `updateMediaStreamImpl` にリネームし、0048 の `reconnectSora` と同形の wrapper パターンでモジュールローカル in-flight Promise を介してガードする
- `UpdateMediaStreamButton.tsx` に `disabled` を追加し、`localMediaStream === null` と `preparing` / `connecting` / `disconnecting` の過渡状態で無効化する（`connected` 中はデバイス切替が主用途のため enable のまま）
- caller は無変更（インターフェース互換）
- 0045 の中断検出ガードは `updateMediaStreamImpl` 内に維持

## 完了条件

- [x] in-flight ガードを追加し、連打しても本体が 1 回しか走らない
- [x] UpdateMediaStreamButton の disabled で過渡状態の押下を防ぐ
- [x] CHANGES.md の \`## develop\` の \`[FIX]\` 末尾にエントリを追加する

## 関連 issue

- issues/closed/0054-bug-fix-update-media-stream-button-disabled.md
- issues/closed/0048 / 0045 / 0053