### PR TITLE
0060 connectSora の preparing / connecting 中の Disconnect で接続が確立する問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -255,6 +255,11 @@
   - `updateMediaStream` をモジュールローカルな in-flight Promise でガードし、連打 / `AudioInputForm` / `VideoInputForm` の onChange と重なっても同時に複数走らないようにする
   - `UpdateMediaStreamButton` の `disabled` に `localMediaStream === null` および `preparing` / `connecting` / `disconnecting` の過渡状態を反映し、対象が無い / 過渡状態での押下を防ぐ（`connected` 中はデバイス切替が主用途のため enable のまま）
   - @voluntas
+- [FIX] `connectSora` の `preparing` / `connecting` 中に Disconnect を押されたときに接続が確立してしまう問題を修正する
+  - `connectSora` 内の 5 箇所の `await` 直後で `connectionStatus === "disconnected"` を検知し、放棄時にローカル変数の `mediaStream` / `audioContext` / `soraConnection` を解放する
+  - 検知時に `event-connect-cancelled` の timeline メッセージを記録する
+  - `preparing` / `connecting` 中の Disconnect を意図的にサポートする既存設計は維持する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0060-bug-fix-connect-sora-cancellation-detection.md
+++ b/issues/closed/0060-bug-fix-connect-sora-cancellation-detection.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/fix-connect-sora-cancellation-detection
 - Polished: 2026-06-16
@@ -293,3 +293,12 @@ signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("connected"));
 - closed/0007 の「`preparing` 中の Disconnect も意図的にサポート」設計が維持されていること (`DisconnectButton` の `disabled` に `preparing` を追加するアプローチは採用しない)。
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 既存テスト ( `pnpm test` ) および既存 Playwright e2e が pass すること。
+
+## 解決方法
+
+- `src/app/actions.ts` に `abortConnectSoraResources` ヘルパー関数を新設し、キャンセル時の `mediaStream` 全 track stop、`audioContext.close`、`signals.setSora(null) + void soraConnection.disconnect()` をまとめた。既存 `localMediaStream` 再利用パスでは track を stop しない判定 (`forceCreateMediaStream || localMediaStreamValue !== mediaStream`) も含む。
+- `connectSora` 内にローカルアロー `abortIfCancelled` を導入し、`connectionStatus === "disconnected"` を検知したら `abortConnectSoraResources` を呼んで `event-connect-cancelled` を timeline に記録、`true` を返す。`mediaStream` / `audioContext` / `soraConnection` などのローカル変数は call site でオブジェクトとして渡し、let 束縛の最新値を反映する。
+- 5 箇所の検知ポイントを追加した。検知ポイント 1（既存接続あり時の `await soraValue.disconnect()` 直後）は専用ガードで `event-connect-cancelled` を記録して return。検知ポイント 2（`mediaStream` 取得後）、検知ポイント 3 / 4（`await connect(...)` 後を共通化して 1 箇所に集約）、検知ポイント 5（`await setStatsReportInternal` 直後）は `abortIfCancelled` を経由する。
+- `connectSora` の statement 数が 50 を超えるため `// oxlint-disable-next-line eslint/max-statements` を理由付きで付与した（ローカル変数の closure 捕捉のため外部関数化せず連結する設計判断）。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追加した。
+- テスト追加なし（`navigator.mediaDevices.getUserMedia` と Sora 接続を jsdom + モック禁止規約で再現不能）。状態遷移は手動検証で網羅する。

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1548,6 +1548,43 @@ function startStatsReportTimer(): void {
   void schedule();
 }
 
+// connectSora のキャンセル時にローカル変数として生成済みの資源を解放する。
+// disconnectSora の cleanupSoraMediaState は signal 経由でしか解放できないため、
+// まだ signal に積まれていない mediaStream / audioContext / soraConnection はここで直接解放する。
+function abortConnectSoraResources(args: {
+  mediaStream: MediaStream | undefined;
+  audioContext: AudioContext | null | undefined;
+  soraConnection: ConnectionPublisher | ConnectionSubscriber | undefined;
+  forceCreateMediaStream: boolean;
+  localMediaStreamValue: MediaStream | null;
+}): void {
+  const {
+    mediaStream,
+    audioContext,
+    soraConnection,
+    forceCreateMediaStream,
+    localMediaStreamValue,
+  } = args;
+  // 既存 localMediaStream を再利用したパスでは mediaStream は signal がまだ保持しているため stop しない。
+  // それ以外のパス (新規取得 / forceCreateMediaStream) では本ヘルパーで track を stop する。
+  if (mediaStream && (forceCreateMediaStream || localMediaStreamValue !== mediaStream)) {
+    for (const track of mediaStream.getTracks()) {
+      track.stop();
+    }
+  }
+  if (audioContext) {
+    void audioContext.close();
+  }
+  if (soraConnection && signals.sora.value === soraConnection) {
+    // 0047 の isCurrent() ガードで disconnect ハンドラは skip されるが、SDK 側の WebSocket
+    // / PeerConnection を確実に close するため disconnect() は呼ぶ。失敗は無視する。
+    signals.setSora(null);
+    void soraConnection.disconnect();
+  }
+  signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-connect-cancelled"));
+}
+
+// oxlint-disable-next-line eslint/max-statements -- 5 箇所のキャンセル検知ポイントとローカル変数の closure 捕捉のため外部関数化せず連結する
 export const connectSora = async (): Promise<void> => {
   signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("start-connection"));
   signals.setSoraConnectionStatus("preparing");
@@ -1560,6 +1597,13 @@ export const connectSora = async (): Promise<void> => {
   const soraValue = signals.sora.value;
   if (soraValue) {
     await soraValue.disconnect();
+    // 検知ポイント 1: 既存接続あり時の await 直後に Disconnect が押された場合の専用ガード。
+    // この時点ではローカル変数 mediaStream / audioContext / soraConnection が未代入のため
+    // 解放処理は不要で、event-connect-cancelled だけ記録して新接続を作らずに return する。
+    if (signals.connectionStatus.value === "disconnected") {
+      signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-connect-cancelled"));
+      return;
+    }
     // 接続中の再接続の場合は、MediaStream を作り直し、state.soraContents.localMediaStream を更新する
     forceCreateMediaStream = true;
   }
@@ -1572,6 +1616,23 @@ export const connectSora = async (): Promise<void> => {
   const channelIdValue = signals.channelId.value;
   const googCpuOveruseDetectionValue = signals.googCpuOveruseDetection.value;
   const localMediaStreamValue = signals.localMediaStream.value;
+  // preparing / connecting 中にユーザーが Disconnect を押すと disconnectSora は soraValue == null
+  // でも setSoraConnectionStatus("disconnected") を立てる (0007 で確立した意図的サポート)。
+  // connectSora 側は各 await 直後に本ヘルパーで disconnected を検知し、ローカル変数の資源を
+  // abortConnectSoraResources で直接解放する。
+  const abortIfCancelled = (): boolean => {
+    if (signals.connectionStatus.value !== "disconnected") {
+      return false;
+    }
+    abortConnectSoraResources({
+      mediaStream,
+      audioContext,
+      soraConnection,
+      forceCreateMediaStream,
+      localMediaStreamValue,
+    });
+    return true;
+  };
   try {
     soraConnection = createSoraConnectionByRole(
       connection,
@@ -1594,6 +1655,10 @@ export const connectSora = async (): Promise<void> => {
           },
         );
       }
+      // 検知ポイント 2: 新規取得パスと再利用パス両方の後で 1 回検知する
+      if (abortIfCancelled()) {
+        return;
+      }
       signals.setSoraConnectionStatus("connecting");
       // 先に setSora で state を参照できるようにしておかないと connection.created の notify が来た時に処理に困るため
       signals.setSora(soraConnection);
@@ -1603,6 +1668,10 @@ export const connectSora = async (): Promise<void> => {
       // 先に setSora で state を参照できるようにしておかないと connection.created の notify が来た時に処理に困るため
       signals.setSora(soraConnection);
       await (soraConnection as ConnectionSubscriber).connect();
+    }
+    // 検知ポイント 3 / 4: connect 直後の共通検知 (sendrecv / sendonly / recvonly いずれも)
+    if (abortIfCancelled()) {
+      return;
     }
   } catch (error) {
     // 先に setSora で state を参照できるようにした state の参照を削除
@@ -1619,6 +1688,11 @@ export const connectSora = async (): Promise<void> => {
   // createSoraConnectionByRole は常に ConnectionPublisher | ConnectionSubscriber を返すため soraConnection は non-null
   signals.setSoraInfoAlertMessage("succeeded to connect Sora");
   await setStatsReportInternal(soraConnection);
+  // 検知ポイント 5: setStatsReportInternal の await 中にも Disconnect が押されうるため、
+  // setSoraConnectionStatus("connected") を立てる前に最終チェックする
+  if (abortIfCancelled()) {
+    return;
+  }
   startStatsReportTimer();
   if (mediaStream && (localMediaStreamValue === null || forceCreateMediaStream)) {
     signals.setLocalMediaStream(mediaStream);


### PR DESCRIPTION
## 概要

`connectSora` が `preparing` / `connecting` 中にユーザーが Disconnect を押した場合、`disconnectSora` は `soraValue == null` で SDK 切断をスキップして `setSoraConnectionStatus("disconnected")` を立てるが、並列で動いている `connectSora` が `setSoraConnectionStatus("connecting")` で上書きし、最終的に接続が確立してしまう経路があった。

## 変更内容

- `abortConnectSoraResources` ヘルパー関数を新設し、キャンセル時の `mediaStream` 全 track stop、`audioContext.close`、`setSora(null) + soraConnection.disconnect()` をまとめる
- `connectSora` 内に 5 つの検知ポイント（既存 sora disconnect 直後、`mediaStream` 取得後、`connect()` 後、`setStatsReportInternal` 直後）を追加し、各 `await` 後に `connectionStatus === "disconnected"` を検知して放棄する
- 検知時に `event-connect-cancelled` の timeline メッセージを記録する
- `preparing` / `connecting` 中の Disconnect を意図的にサポートする既存設計は維持する

## 完了条件

- [x] 5 箇所の検知ポイントで `disconnected` 検知
- [x] 放棄時にローカル変数の `mediaStream` / `audioContext` / `soraConnection` を解放
- [x] `event-connect-cancelled` を timeline に記録
- [x] CHANGES.md の \`## develop\` の \`[FIX]\` 末尾にエントリを追加する

## 関連 issue

- issues/closed/0060-bug-fix-connect-sora-cancellation-detection.md