### PR TITLE
0041 track イベントで event.streams が空配列のときの防御を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -260,6 +260,8 @@
   - 検知時に `event-connect-cancelled` の timeline メッセージを記録する
   - `preparing` / `connecting` 中の Disconnect を意図的にサポートする既存設計は維持する
   - @voluntas
+- [FIX] `track` イベントで `event.streams` が空配列のときの防御を追加する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0041-bug-fix-track-event-streams-null-check.md
+++ b/issues/closed/0041-bug-fix-track-event-streams-null-check.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/fix-track-event-streams-null-check
 - Polished: 2026-06-16
@@ -124,3 +124,10 @@ export const handleTrackEvent = (event: RTCTrackEvent): void => {
 - 空配列イベント到達時に `TypeError` が発生せず、`remoteClients` も書き換えられないこと（テストで確認）。
 - `CHANGES.md` の `## develop` の `[FIX]` セクション末尾に上記エントリが追記され、担当者行が付いていること。
 - 既存 Playwright e2e（`pnpm test:e2e`）が通ること。
+
+## 解決方法
+
+- `src/app/actions.ts` の `setSoraCallbacks` 内 `"track"` リスナー本体を `handleTrackEvent` として export 関数に切り出した。`isCurrent()` 判定は `setSoraCallbacks` 側のラッパに残し、`handleTrackEvent` 本体はテスト時に `signals.sora.value` の設定を要しない形にした。
+- `handleTrackEvent` 冒頭に `event.streams.length === 0` の早期 return を追加した。空配列のときは `remoteClients` を変更せず、`event-on-track` の timeline メッセージを 2 件（無条件 + `emptyStreams / trackId / kind` 付き）追加して return する。既存の `event.streams[0]` 参照 6 箇所はそのまま残した。
+- `src/app/actions.test.ts` に `handleTrackEvent` の空配列ガードのテスト 3 件を追加した。`assert.doesNotThrow` で例外を投げない契約を表明し、`remoteClients` が変更されないこと、timeline メッセージが 2 件追加されることを検証する。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追加した。

--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -1,12 +1,13 @@
 import { assert, test } from "vite-plus/test";
 
 import type { SoraNotifyMessage } from "../types.ts";
-import { cleanupSoraMediaState, isConnectionDestroyedNotify } from "./actions.ts";
+import { cleanupSoraMediaState, handleTrackEvent, isConnectionDestroyedNotify } from "./actions.ts";
 import {
   fakeContents,
   localMediaStream,
   noiseSuppressionProcessor,
   remoteClients,
+  timelineMessages,
   virtualBackgroundProcessor,
 } from "./signals.ts";
 
@@ -91,4 +92,55 @@ test("cleanupSoraMediaState を 2 回連続で await しても例外を投げな
   await cleanupSoraMediaState();
   assert.equal(localMediaStream.value, null);
   assert.equal(remoteClients.value.length, 0);
+});
+
+// handleTrackEvent の空配列ガードのテスト
+// RTCTrackEvent は jsdom にコンストラクタが無いため、必須プロパティのみのリテラルを型キャストして渡す
+test("handleTrackEvent は streams が空配列のとき例外を投げない", () => {
+  remoteClients.value = [];
+  timelineMessages.value = [];
+  const emptyEvent = {
+    streams: [],
+    track: { id: "t1", kind: "audio" },
+  } as unknown as RTCTrackEvent;
+  // assert.doesNotThrow で「例外を投げない」契約を直接表現する
+  assert.doesNotThrow(() => {
+    handleTrackEvent(emptyEvent);
+  });
+});
+
+test("handleTrackEvent は streams が空配列のとき remoteClients を変更しない", () => {
+  remoteClients.value = [];
+  timelineMessages.value = [];
+  const emptyEvent = {
+    streams: [],
+    track: { id: "t1", kind: "audio" },
+  } as unknown as RTCTrackEvent;
+  handleTrackEvent(emptyEvent);
+  assert.equal(remoteClients.value.length, 0);
+});
+
+test("handleTrackEvent は streams が空配列のとき event-on-track の timeline メッセージを 2 件追加する", () => {
+  remoteClients.value = [];
+  timelineMessages.value = [];
+  const beforeLength = timelineMessages.value.length;
+  const emptyEvent = {
+    streams: [],
+    track: { id: "t1", kind: "audio" },
+  } as unknown as RTCTrackEvent;
+  handleTrackEvent(emptyEvent);
+  const after = timelineMessages.value.slice(beforeLength);
+  // 差分 2 件: 冒頭の無条件 event-on-track と空配列ガード時の event-on-track (data 付き)
+  assert.equal(after.length, 2);
+  // 1 件目: type === "event-on-track" かつ data === undefined
+  assert.equal(after[0].type, "event-on-track");
+  assert.equal(after[0].data, undefined);
+  // 2 件目: type === "event-on-track" かつ data オブジェクトで emptyStreams / trackId / kind を持つ
+  assert.equal(after[1].type, "event-on-track");
+  const secondData = after[1].data;
+  // TimelineMessage.data は Record<string, unknown> | undefined のため、まず undefined でないことを確認してから個別キーをアサートする
+  assert.exists(secondData);
+  assert.equal(secondData.emptyStreams, true);
+  assert.equal(secondData.trackId, "t1");
+  assert.equal(secondData.kind, "audio");
 });

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1083,6 +1083,48 @@ export const cleanupSoraMediaState = async (): Promise<void> => {
   }
 };
 
+// track イベントの本体処理を切り出す。setSoraCallbacks 側のラッパで isCurrent() 判定を通過した後に呼ばれる。
+// 0047 の isCurrent ガードを setSoraCallbacks 側で適用済みのため本関数では再判定しない (テスト時に signals.sora を設定する必要が無くなる)。
+// event.streams が空配列の場合は remoteClients を変更せず timeline メッセージのみ追加して return する。
+// 現行 sora-js-sdk は publisher 系で明示ガードしており subscriber 系も TypeError 経由で空配列イベントが到達しない設計だが、
+// SDK の比較順や connectionId 判定が変わると即座に空配列イベントが到達しうるためアプリ層にも防御層を入れる。
+export const handleTrackEvent = (event: RTCTrackEvent): void => {
+  signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-on-track"));
+  if (event.streams.length === 0) {
+    signals.setTimelineMessage(
+      createSoraDevtoolsTimelineMessage("event-on-track", {
+        emptyStreams: true,
+        trackId: event.track.id,
+        kind: event.track.kind,
+      }),
+    );
+    return;
+  }
+  const remoteClientsValue = signals.remoteClients.value;
+  const mediaStream = remoteClientsValue.find(
+    (client) => client.connectionId === event.streams[0].id,
+  );
+  if (!mediaStream) {
+    for (const track of event.streams[0].getTracks()) {
+      signals.setTimelineMessage(
+        createSoraDevtoolsTimelineMessage(
+          `remote-${track.kind}-mediastream-track`,
+          getMediaStreamTrackProperties(track),
+        ),
+      );
+    }
+    signals.setRemoteClient({
+      mediaStream: event.streams[0],
+      connectionId: event.streams[0].id,
+      clientId: null,
+    });
+  }
+  // 新規・既存クライアントに関わらず全 track の ended リスナーを登録する
+  for (const track of event.streams[0].getTracks()) {
+    registerTrackEndedListener(event.streams[0].id, track);
+  }
+};
+
 // Sora connection オブジェクトに callback をセットする
 function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscriber): void {
   // sora-js-sdk にはリスナー解除 API (off / removeAllListeners) が無く、reconnectSora で
@@ -1132,30 +1174,7 @@ function setSoraCallbacks(soraConnection: ConnectionPublisher | ConnectionSubscr
     if (!isCurrent()) {
       return;
     }
-    signals.setTimelineMessage(createSoraDevtoolsTimelineMessage("event-on-track"));
-    const remoteClientsValue = signals.remoteClients.value;
-    const mediaStream = remoteClientsValue.find(
-      (client) => client.connectionId === event.streams[0].id,
-    );
-    if (!mediaStream) {
-      for (const track of event.streams[0].getTracks()) {
-        signals.setTimelineMessage(
-          createSoraDevtoolsTimelineMessage(
-            `remote-${track.kind}-mediastream-track`,
-            getMediaStreamTrackProperties(track),
-          ),
-        );
-      }
-      signals.setRemoteClient({
-        mediaStream: event.streams[0],
-        connectionId: event.streams[0].id,
-        clientId: null,
-      });
-    }
-    // 新規・既存クライアントに関わらず全 track の ended リスナーを登録する
-    for (const track of event.streams[0].getTracks()) {
-      registerTrackEndedListener(event.streams[0].id, track);
-    }
+    handleTrackEvent(event);
   });
   soraConnection.on("removetrack", (event: MediaStreamTrackEvent) => {
     // SDK イベント発火そのものは古い接続でも timeline に残す（append-only で state 破壊なし）


### PR DESCRIPTION
## 概要

`soraConnection.on("track", ...)` ハンドラが `event.streams[0]` を 6 箇所で空配列ガードなく参照していた。現行 sora-js-sdk では実害が無いが、SDK 内の防御挙動が変わると即座に空配列イベントが到達して `TypeError` を起こすため、アプリ層にも二段防御を追加する。

## 変更内容

- `src/app/actions.ts` の `setSoraCallbacks` 内 `"track"` リスナー本体を `handleTrackEvent` として export 切り出しする
- `handleTrackEvent` 冒頭で `event.streams.length === 0` を検知して `event-on-track` の timeline メッセージのみ追加して return する
- `setSoraCallbacks` 側のラッパに `isCurrent()` 判定を残し、テスト時に `signals.sora.value` の設定を要しない形にする
- `src/app/actions.test.ts` に空配列ガードの単体テスト 3 件を追加する

## 完了条件

- [x] `handleTrackEvent` を export して単体テスト可能にする
- [x] 空配列イベント到達時に `TypeError` が出ず `remoteClients` も変更されない
- [x] CHANGES.md の \`## develop\` の \`[FIX]\` 末尾にエントリを追加する

## 関連 issue

- issues/closed/0041-bug-fix-track-event-streams-null-check.md