### PR TITLE
0057 DownloadReportButton の Blob URL リークを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -262,6 +262,10 @@
   - @voluntas
 - [FIX] `track` イベントで `event.streams` が空配列のときの防御を追加する
   - @voluntas
+- [FIX] `DownloadReportButton` の `Blob URL` がリークする問題を修正する
+  - `URL.createObjectURL` で発行した `Blob URL` を `useRef` で保持し、次回押下時に `URL.revokeObjectURL` で解放する
+  - `useEffect` cleanup でアンマウント時の最終 `Blob URL` も解放する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0057-bug-fix-download-report-blob-leak.md
+++ b/issues/closed/0057-bug-fix-download-report-blob-leak.md
@@ -2,7 +2,7 @@
 
 - Priority: Low
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/fix-download-report-blob-leak
 - Polished: 2026-06-16
@@ -215,3 +215,12 @@ export function DownloadReportButton() {
 - `useEffect` cleanup が登録され、アンマウント時に最終 URL が revoke されること。
 - `CHANGES.md` の `## develop` の `[FIX]` 末尾に上記エントリが追記され、担当者行が付いていること。
 - 既存テスト（`pnpm test`）および既存 Playwright e2e が pass すること。
+
+## 解決方法
+
+- `src/components/Header/DownloadReportButton.tsx` に `useRef<string | null>(null)` の `previousBlobUrlRef` を追加し、直前に発行した Blob URL を保持する。次回 click 時に `revokeObjectURL` で解放する。
+- `onClick` 内で `globalThis.URL.createObjectURL(blob)` の戻り値をローカル変数 `blobUrl` に格納し、`anchor.href` に代入してから `previousBlobUrlRef.current` が非 null の場合のみ `revokeObjectURL` を呼ぶ。直後に `previousBlobUrlRef.current = blobUrl` で更新する。初回 click 時は previousBlobUrlRef.current が null なので revoke は skip される。
+- `useEffect(() => () => { ... }, [])` で cleanup を登録し、アンマウント時に最終 Blob URL を `revokeObjectURL` で解放して `previousBlobUrlRef.current = null` にする。issue サンプルの明示 return 形式は oxlint の `arrow-body-style` 制約により暗黙 return 形式に変更したが、機能的には完全同等。
+- `import { useRef } from "preact/hooks";` を `import { useEffect, useRef } from "preact/hooks";` に変更した。
+- `CHANGES.md` の `## develop` の `[FIX]` セクション末尾にエントリを追加した。
+- テスト追加なし（Preact コンポーネントの click ハンドラの副作用を読み取る単体テスト基盤が無く、モック禁止規約と両立しないため）。手動検証で確認する。

--- a/src/components/Header/DownloadReportButton.tsx
+++ b/src/components/Header/DownloadReportButton.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import Sora from "sora-js-sdk";
 
 import { Button } from "@/components/ui";
@@ -177,6 +177,10 @@ function createDownloadReport(): DownloadReport {
 
 export function DownloadReportButton() {
   const anchorRef = useRef<HTMLAnchorElement>(null);
+  // 直前に発行した Blob URL を保持する。次回 click 時に revokeObjectURL で解放する。
+  // W3C File API: createObjectURL は Blob URL Store にエントリを生成し Blob 本体への
+  // 参照を保持する。revokeObjectURL を呼ばないと Blob は GC されない。
+  const previousBlobUrlRef = useRef<string | null>(null);
   const onClick = (): void => {
     const report = createDownloadReport();
     const data = JSON.stringify(report);
@@ -185,10 +189,29 @@ export function DownloadReportButton() {
     if (anchorRef.current) {
       const datetimeString = new Date().toISOString().replaceAll(":", "_").replaceAll(".", "_");
       anchorRef.current.download = `sora-devtools-report-${datetimeString}.json`;
-      anchorRef.current.href = globalThis.URL.createObjectURL(blob);
+      const blobUrl = globalThis.URL.createObjectURL(blob);
+      anchorRef.current.href = blobUrl;
       anchorRef.current.click();
+      // 直前の URL を revoke する。W3C File API 仕様 Note
+      // 「Requests that were started before the url was revoked should still succeed」
+      // により、anchor.click() で開始した download fetch は revoke 後も成功する。
+      // 初回 click 時は previousBlobUrlRef.current が null のため no-op。
+      if (previousBlobUrlRef.current !== null) {
+        globalThis.URL.revokeObjectURL(previousBlobUrlRef.current);
+      }
+      previousBlobUrlRef.current = blobUrl;
     }
   };
+  // アンマウント時に最終 URL を解放する。Header は通常永続だが leak を完全に閉じるため明示する。
+  useEffect(
+    () => () => {
+      if (previousBlobUrlRef.current !== null) {
+        globalThis.URL.revokeObjectURL(previousBlobUrlRef.current);
+        previousBlobUrlRef.current = null;
+      }
+    },
+    [],
+  );
   return (
     <>
       <Button variant="light" size="sm" className="ml-1" onClick={onClick}>


### PR DESCRIPTION
## 概要

`DownloadReportButton` が click のたびに `URL.createObjectURL(blob)` で Blob URL を生成するが、`URL.revokeObjectURL` を呼んでいなかった。W3C File API の Blob URL Store に古いエントリが残り続け、Blob 本体（数 MB 〜 数十 MB）が GC されない。

## 変更内容

- `useRef<string | null>` で直前の Blob URL を保持し、次回 click 時に `URL.revokeObjectURL` で解放する
- `useEffect` cleanup でアンマウント時の最終 Blob URL も解放する
- W3C File API 仕様 Note「Requests that were started before the url was revoked should still succeed」により、進行中の download fetch は revoke 後も成功する

## 完了条件

- [x] useRef で前回 URL を保持し次回 click 時に revoke
- [x] useEffect cleanup でアンマウント時も解放
- [x] CHANGES.md の \`## develop\` の \`[FIX]\` 末尾にエントリを追加する

## 関連 issue

- issues/closed/0057-bug-fix-download-report-blob-leak.md