### PR TITLE
Firefox でマルチストリームの re-offer 後にリモート映像が真っ白になる問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@
   - `disconnected` 状態で `Disconnect` を押した場合も残留メディアを掃除する
   - `ConnectButton` の `preparing` 中の二重押下を防止する
   - @voluntas
+- [FIX] `Firefox` でマルチストリームの re-offer 後にリモート映像が真っ白になる問題を修正する
+  - `removeRemoteClientCleanup` で他参加者退出時の remote track を `stop()` していたのを止める
+  - 接続継続中に remote track を stop() すると、`Firefox` で同じ transceiver 周りの後続 track イベントが正しく処理されなくなるため、signal からの削除のみ行い track の停止は SDK 側の re-offer 処理に任せる
+  - @voluntas
 - [FIX] dev 環境で `.env` の `VITE_SORA_SIGNALING_URL` が反映されなかった問題を修正する
   - `createSignalingURL` の dev 用フォールバック分岐で参照していた `import.meta.env.NODE_ENV` を `import.meta.env.DEV` に置き換える
   - `import.meta.env.NODE_ENV` は Vite がクライアントに注入しないキーであり常に `undefined` を返すため `.env` の上書きが無効化されていた

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1020,19 +1020,17 @@ const unregisterTrackEndedListeners = (connectionId: string): void => {
   }
 };
 
-// リモートクライアントを ended リスナー解除つきで個別に削除する
+// リモートクライアントを ended リスナーを解除しつつ個別に削除する
 //
 // 他参加者が channel から退出した場合に、remoteClients signal から該当クライアントを
 // 削除し、登録済みの track ended リスナーを解除する。
 //
 // 注意: ここでは remote track を stop() しない。
-// issue 0030 では「切断後も映像が UI に残る」対策として track.stop() を行っていたが、
 // 接続継続中のマルチストリーム session で他参加者が退出・再接続する re-offer 時に、
 // Firefox では stop() 済みの remote track と同一 transceiver に紐づく後続 track イベントが
-// 正しく処理されず、再接続後の映像が真っ白になる問題が発生した。
-// そのため、個別削除時は signal からの削除のみ行い、track の停止は sora-js-sdk 側の
-// re-offer 処理に任せる。フル切断時の一括掃除（clearRemoteMediaClients）では、
-// リソース解放のため引き続き track.stop() を行う。
+// 正しく処理されず、再接続後の映像が真っ白になる問題が発生する。
+// そのため signal からの削除のみ行い、track の停止は sora-js-sdk 側の re-offer 処理に任せる。
+// フル切断時の一括掃除（clearRemoteMediaClients）では、リソース解放のため引き続き track.stop() を行う。
 const removeRemoteClientCleanup = (connectionId: string): void => {
   unregisterTrackEndedListeners(connectionId);
   signals.removeRemoteClient(connectionId);

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1020,17 +1020,22 @@ const unregisterTrackEndedListeners = (connectionId: string): void => {
   }
 };
 
-// リモートクライアントを track 停止・リスナー解除つきで個別に削除する
+// リモートクライアントを ended リスナー解除つきで個別に削除する
+//
+// 他参加者が channel から退出した場合に、remoteClients signal から該当クライアントを
+// 削除し、登録済みの track ended リスナーを解除する。
+//
+// 注意: ここでは remote track を stop() しない。
+// issue 0030 では「切断後も映像が UI に残る」対策として track.stop() を行っていたが、
+// 接続継続中のマルチストリーム session で他参加者が退出・再接続する re-offer 時に、
+// Firefox では stop() 済みの remote track と同一 transceiver に紐づく後続 track イベントが
+// 正しく処理されず、再接続後の映像が真っ白になる問題が発生した。
+// そのため、個別削除時は signal からの削除のみ行い、track の停止は sora-js-sdk 側の
+// re-offer 処理に任せる。フル切断時の一括掃除（clearRemoteMediaClients）では、
+// リソース解放のため引き続き track.stop() を行う。
 const removeRemoteClientCleanup = (connectionId: string): void => {
   unregisterTrackEndedListeners(connectionId);
-  const remoteClientsValue = signals.remoteClients.value;
-  const remoteClient = remoteClientsValue.find((client) => client.connectionId === connectionId);
-  if (remoteClient) {
-    for (const track of remoteClient.mediaStream.getTracks()) {
-      track.stop();
-    }
-    signals.removeRemoteClient(connectionId);
-  }
+  signals.removeRemoteClient(connectionId);
 };
 
 // リモートクライアント全件の track 停止・ended リスナー解除後に signal を一括クリアする


### PR DESCRIPTION
## 変更内容\n\n-  から他参加者退出時の remote track  を削除\n- 接続継続中のマルチストリーム session で re-offer 時に Firefox で同じ transceiver 周りの後続 track イベントが正しく処理されなくなる問題を回避\n- フル切断時の一括掃除（）では引き続き  を維持\n- コメントから issue 番号への言及を削除\n\n## CHANGES.md\n\n- [FIX]  でマルチストリームの re-offer 後にリモート映像が真っ白になる問題を修正する