### PR TITLE
0037 e2e テストに Page Object Model を導入する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 
 ## develop
 
+### misc
+
+- [ADD] e2e テストに Page Object Model と環境変数読み込みヘルパーを導入する
+  - @voluntas
+
 ## 2026.1.0
 
 **リリース日**: 2026-06-18

--- a/issues/closed/0037-refactor-introduce-e2e-page-object.md
+++ b/issues/closed/0037-refactor-introduce-e2e-page-object.md
@@ -2,7 +2,7 @@
 
 - Priority: High
 - Created: 2026-06-08
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-07-10
 - Model: DeepSeek V4 Pro
 - Branch: feature/refactor-introduce-e2e-page-object
 - Polished: 2026-07-10
@@ -252,11 +252,11 @@ Sora 接続成功パス ( `E2E_TEST_SORA_SIGNALING_URL` 設定済み) は既存�
 
 ## 解決方法
 
-1. `tests/helpers/env.ts` を新規作成し、上記 API 仕様どおり `getSoraConnectionEnv()` を実装する
-2. `tests/pages/DevtoolsPage.ts` を新規作成し、上記 API 仕様どおり `navigate` / `connect` / `disconnect` / `waitForConnection` / `getConnectionId` を実装する。`navigate` は `page.goto` を使う
-3. `tests/sendrecv.test.ts` / `tests/sendonly.test.ts` / `tests/recvonly.test.ts` を上記テンプレートに置き換える (差分はテスト名 / `role` / `channelId` suffix のみ)
-4. `CHANGES.md` の `## develop` に `### misc` を新設し、`[ADD]` エントリと担当者行を追記する
-5. `vp check` / `vp test run` / `pnpm test:e2e` (設定あり・なし) で完了条件を確認する
+1. `tests/helpers/env.ts` を新規作成し、`getSoraConnectionEnv()` を実装した。`E2E_TEST_SORA_SIGNALING_URL` が未設定または空文字のとき `undefined` を返し、それ以外は `channelIdPrefix` / `accessToken` を空文字既定で正規化して返す
+2. `tests/pages/DevtoolsPage.ts` を新規作成し、`navigate` / `connect` / `disconnect` / `waitForConnection` / `getConnectionId` を実装した。セレクタとベース URL をクラス内に集約し、空配列の `signalingUrlCandidates` は Error を throw する
+3. `tests/sendrecv.test.ts` / `tests/sendonly.test.ts` / `tests/recvonly.test.ts` を Page Object テンプレートに置き換え、`multistream: "true"` と `// TODO: 複数に対応したい` を削除した
+4. `CHANGES.md` の `## develop` に `### misc` と `[ADD]` エントリを追記した
+5. `vp check` / `vp test run` / `pnpm test:e2e` (設定あり・ `E2E_TEST_SORA_SIGNALING_URL=` 未設定) で完了条件を確認した
 
 ## エッジケース
 

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -1,0 +1,27 @@
+// Sora 接続テストに必要な環境変数を解決した結果
+export interface SoraConnectionEnv {
+  signalingUrl: string;
+  channelIdPrefix: string;
+  accessToken: string;
+}
+
+// 環境変数を読み込み、必須が未設定なら undefined を返す
+// `E2E_TEST_SORA_SIGNALING_URL` のみ必須。`undefined` または空文字を「未設定」とみなす
+// `E2E_TEST_SORA_CHANNEL_ID_PREFIX` 未設定時は空文字を既定値とする
+// `E2E_TEST_ACCESS_TOKEN` 未設定時は空文字を既定値とする (任意値でよい変数のため、未設定は空文字に正規化する)
+export function getSoraConnectionEnv(): SoraConnectionEnv | undefined {
+  const signalingUrl = process.env.E2E_TEST_SORA_SIGNALING_URL;
+
+  if (signalingUrl === undefined || signalingUrl === "") {
+    return undefined;
+  }
+
+  const channelIdPrefix = process.env.E2E_TEST_SORA_CHANNEL_ID_PREFIX ?? "";
+  const accessToken = process.env.E2E_TEST_ACCESS_TOKEN ?? "";
+
+  return {
+    signalingUrl,
+    channelIdPrefix,
+    accessToken,
+  };
+}

--- a/tests/pages/DevtoolsPage.ts
+++ b/tests/pages/DevtoolsPage.ts
@@ -1,0 +1,92 @@
+import type { Page } from "@playwright/test";
+
+// e2e テストで扱う接続ロール
+// `src/` への依存を持たないため Page Object 内で独立定義する
+// `src/constants.ts` の `ROLES` に新メンバが追加された場合は本型を追従させる (型レベルの自動検出はできない)
+export type Role = "sendrecv" | "sendonly" | "recvonly";
+
+// e2e テストで指定可能な動画コーデック
+// `src/constants.ts` の `VIDEO_CODEC_TYPES` から空文字を除いた値を、配列順どおりに採用する
+// 空文字 (= 未指定扱い) を URL に乗せたい場合は `videoCodecType: undefined` を使う
+export type VideoCodecType = "VP8" | "VP9" | "AV1" | "H264" | "H265";
+
+// Devtools ページに渡す接続パラメータ
+// `signalingUrlCandidates` / `metadata` の JSON 化は本 Page Object の `navigate` 内で行う
+// `parseQueryString` が受け付けないキー ( `multistream` 等) は意図的に含めない
+export interface ConnectionParams {
+  role: Role;
+  channelId: string;
+  signalingUrlCandidates: string[];
+  accessToken: string;
+  videoCodecType?: VideoCodecType;
+}
+
+// Devtools ページの操作をカプセル化する Page Object
+// `DevtoolsPage` / `Role` / `VideoCodecType` / `ConnectionParams` はすべて named export とする (default export は使わない)
+export class DevtoolsPage {
+  // 既存テストと同じくベース URL はクラス内に集約する
+  // `playwright.config.ts` に `use.baseURL` は無いため絶対 URL を使う
+  private static readonly DEVTOOLS_URL = "http://localhost:3333/devtools/";
+
+  // 接続ボタンのセレクタ
+  private static readonly CONNECT_BUTTON_SELECTOR = 'button[name="connect"]';
+
+  // 切断ボタンのセレクタ
+  private static readonly DISCONNECT_BUTTON_SELECTOR = 'button[name="disconnect"]';
+
+  // 接続 ID 表示要素のセレクタ
+  private static readonly CONNECTION_ID_SELECTOR = "#local-video-connection-id";
+
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  // 論理パラメータを URLSearchParams に組み立て、`page.goto` で遷移する
+  // query のキーは channelId / role / signalingUrlCandidates / metadata と、指定時のみ videoCodecType
+  // `signalingUrlCandidates` が空配列なら Error を throw する
+  async navigate(params: ConnectionParams): Promise<void> {
+    if (params.signalingUrlCandidates.length === 0) {
+      throw new Error("expected non-empty signalingUrlCandidates, got []");
+    }
+
+    const query = new URLSearchParams({
+      channelId: params.channelId,
+      role: params.role,
+      signalingUrlCandidates: JSON.stringify(params.signalingUrlCandidates),
+      metadata: JSON.stringify({ access_token: params.accessToken }),
+    });
+
+    if (params.videoCodecType !== undefined) {
+      query.set("videoCodecType", params.videoCodecType);
+    }
+
+    await this.page.goto(`${DevtoolsPage.DEVTOOLS_URL}?${query.toString()}`);
+  }
+
+  // 接続ボタンをクリックする
+  // Playwright の `Page.click` の actionability 待機は維持する (接続完了の待機は `waitForConnection` の責務)
+  async connect(): Promise<void> {
+    await this.page.click(DevtoolsPage.CONNECT_BUTTON_SELECTOR);
+  }
+
+  // 切断ボタンをクリックする (Playwright の `Page.click` の actionability 待機は維持する。切断完了の待機は本メソッドの責務外)
+  async disconnect(): Promise<void> {
+    await this.page.click(DevtoolsPage.DISCONNECT_BUTTON_SELECTOR);
+  }
+
+  // 接続 ID が表示されるまで待機する
+  // デフォルト timeout は既存テストの `page.waitForSelector` に合わせ 5000 ms
+  async waitForConnection(timeoutMs = 5000): Promise<void> {
+    await this.page.waitForSelector(DevtoolsPage.CONNECTION_ID_SELECTOR, {
+      timeout: timeoutMs,
+    });
+  }
+
+  // 接続 ID 文字列を取得する。`waitForConnection` 直後に呼ぶ前提
+  // 戻り値型は既存テストの `page.textContent` をそのまま踏襲する
+  async getConnectionId(): Promise<string | null> {
+    return this.page.textContent(DevtoolsPage.CONNECTION_ID_SELECTOR);
+  }
+}

--- a/tests/recvonly.test.ts
+++ b/tests/recvonly.test.ts
@@ -1,37 +1,31 @@
 import { test } from "@playwright/test";
 
+import { getSoraConnectionEnv } from "./helpers/env.ts";
+import { DevtoolsPage } from "./pages/DevtoolsPage.ts";
+
 test("recvonly", async ({ page }) => {
-  // TODO: 複数に対応したい
-  const signalingUrl = process.env.E2E_TEST_SORA_SIGNALING_URL;
-  const channelIdPrefix = process.env.E2E_TEST_SORA_CHANNEL_ID_PREFIX;
-  const accessToken = process.env.E2E_TEST_ACCESS_TOKEN;
+  // 環境変数を取得する。未設定時は空文字を含む既定値となり、[""] 経路で接続が失敗する
+  const env = getSoraConnectionEnv() ?? {
+    signalingUrl: "",
+    channelIdPrefix: "",
+    accessToken: "",
+  };
 
-  const channelId = `${channelIdPrefix}recvonly`;
-
-  const params = new URLSearchParams({
-    channelId,
-    signalingUrlCandidates: JSON.stringify([signalingUrl]),
-    multistream: "true",
+  const devtools = new DevtoolsPage(page);
+  await devtools.navigate({
     role: "recvonly",
+    channelId: `${env.channelIdPrefix}recvonly`,
+    signalingUrlCandidates: [env.signalingUrl],
+    accessToken: env.accessToken,
     videoCodecType: "VP9",
-    metadata: JSON.stringify({ access_token: accessToken }),
   });
 
-  await page.goto(`http://localhost:3333/devtools/?${params.toString()}`);
+  await devtools.connect();
+  await devtools.waitForConnection();
 
-  await page.click('button[name="connect"]');
-
-  // '#local-video-connection-id' が表示されるまで待つ
-  await page.waitForSelector("#local-video-connection-id", { timeout: 5000 });
-
-  // '#local-video-connection-id' のテキストコンテンツを取得する
-  const connectionId = await page.textContent("#local-video-connection-id");
-
-  // 取得したテキストコンテンツをコンソールに出力する
+  const connectionId = await devtools.getConnectionId();
   console.log("Connection ID:", connectionId);
 
-  // 3 秒待つ
   await page.waitForTimeout(3000);
-
-  await page.click('button[name="disconnect"]');
+  await devtools.disconnect();
 });

--- a/tests/sendonly.test.ts
+++ b/tests/sendonly.test.ts
@@ -1,37 +1,31 @@
 import { test } from "@playwright/test";
 
+import { getSoraConnectionEnv } from "./helpers/env.ts";
+import { DevtoolsPage } from "./pages/DevtoolsPage.ts";
+
 test("sendonly", async ({ page }) => {
-  // TODO: 複数に対応したい
-  const signalingUrl = process.env.E2E_TEST_SORA_SIGNALING_URL;
-  const channelIdPrefix = process.env.E2E_TEST_SORA_CHANNEL_ID_PREFIX;
-  const accessToken = process.env.E2E_TEST_ACCESS_TOKEN;
+  // 環境変数を取得する。未設定時は空文字を含む既定値となり、[""] 経路で接続が失敗する
+  const env = getSoraConnectionEnv() ?? {
+    signalingUrl: "",
+    channelIdPrefix: "",
+    accessToken: "",
+  };
 
-  const channelId = `${channelIdPrefix}sendonly`;
-
-  const params = new URLSearchParams({
-    channelId,
-    signalingUrlCandidates: JSON.stringify([signalingUrl]),
-    multistream: "true",
+  const devtools = new DevtoolsPage(page);
+  await devtools.navigate({
     role: "sendonly",
+    channelId: `${env.channelIdPrefix}sendonly`,
+    signalingUrlCandidates: [env.signalingUrl],
+    accessToken: env.accessToken,
     videoCodecType: "VP9",
-    metadata: JSON.stringify({ access_token: accessToken }),
   });
 
-  await page.goto(`http://localhost:3333/devtools/?${params.toString()}`);
+  await devtools.connect();
+  await devtools.waitForConnection();
 
-  await page.click('button[name="connect"]');
-
-  // '#local-video-connection-id' が表示されるまで待つ
-  await page.waitForSelector("#local-video-connection-id", { timeout: 5000 });
-
-  // '#local-video-connection-id' のテキストコンテンツを取得する
-  const connectionId = await page.textContent("#local-video-connection-id");
-
-  // 取得したテキストコンテンツをコンソールに出力する
+  const connectionId = await devtools.getConnectionId();
   console.log("Connection ID:", connectionId);
 
-  // 3 秒待つ
   await page.waitForTimeout(3000);
-
-  await page.click('button[name="disconnect"]');
+  await devtools.disconnect();
 });

--- a/tests/sendrecv.test.ts
+++ b/tests/sendrecv.test.ts
@@ -1,37 +1,31 @@
 import { test } from "@playwright/test";
 
+import { getSoraConnectionEnv } from "./helpers/env.ts";
+import { DevtoolsPage } from "./pages/DevtoolsPage.ts";
+
 test("sendrecv", async ({ page }) => {
-  // TODO: 複数に対応したい
-  const signalingUrl = process.env.E2E_TEST_SORA_SIGNALING_URL;
-  const channelIdPrefix = process.env.E2E_TEST_SORA_CHANNEL_ID_PREFIX;
-  const accessToken = process.env.E2E_TEST_ACCESS_TOKEN;
+  // 環境変数を取得する。未設定時は空文字を含む既定値となり、[""] 経路で接続が失敗する
+  const env = getSoraConnectionEnv() ?? {
+    signalingUrl: "",
+    channelIdPrefix: "",
+    accessToken: "",
+  };
 
-  const channelId = `${channelIdPrefix}sendrecv`;
-
-  const params = new URLSearchParams({
-    channelId,
-    signalingUrlCandidates: JSON.stringify([signalingUrl]),
-    multistream: "true",
+  const devtools = new DevtoolsPage(page);
+  await devtools.navigate({
     role: "sendrecv",
+    channelId: `${env.channelIdPrefix}sendrecv`,
+    signalingUrlCandidates: [env.signalingUrl],
+    accessToken: env.accessToken,
     videoCodecType: "VP9",
-    metadata: JSON.stringify({ access_token: accessToken }),
   });
 
-  await page.goto(`http://localhost:3333/devtools/?${params.toString()}`);
+  await devtools.connect();
+  await devtools.waitForConnection();
 
-  await page.click('button[name="connect"]');
-
-  // '#local-video-connection-id' が表示されるまで待つ
-  await page.waitForSelector("#local-video-connection-id", { timeout: 5000 });
-
-  // '#local-video-connection-id' のテキストコンテンツを取得する
-  const connectionId = await page.textContent("#local-video-connection-id");
-
-  // 取得したテキストコンテンツをコンソールに出力する
+  const connectionId = await devtools.getConnectionId();
   console.log("Connection ID:", connectionId);
 
-  // 3 秒待つ
   await page.waitForTimeout(3000);
-
-  await page.click('button[name="disconnect"]');
+  await devtools.disconnect();
 });


### PR DESCRIPTION
## 概要

Playwright e2e テストに Page Object Model と環境変数読み込みヘルパーを導入し、Sora 接続テスト 3 件の重複を共通化する。

## 変更内容

- `tests/helpers/env.ts` に `getSoraConnectionEnv()` を追加する
- `tests/pages/DevtoolsPage.ts` に接続フロー用 Page Object を追加する
- `sendrecv` / `sendonly` / `recvonly` テストを Page Object テンプレートに置き換える
- 無効な `multistream: "true"` URL パラメータと TODO コメントを削除する
- `CHANGES.md` の `## develop` に `### misc` の `[ADD]` エントリを追記する

## 完了条件

- [x] `DevtoolsPage` / `getSoraConnectionEnv` が API 仕様どおり実装されている
- [x] `tests/` から `src/` への import が無い
- [x] 3 テストファイルの差分がテスト名 / role / channelId suffix のみ
- [x] `vp check` / `vp test run` が通過する
- [x] `E2E_TEST_SORA_SIGNALING_URL` 設定時に Sora 依存 e2e 3 件が通過する
- [x] 未設定時に Sora 依存 e2e 3 件が `waitForConnection` タイムアウトで失敗する

## 関連 issue

- issues/closed/0037-refactor-introduce-e2e-page-object.md