### PR TITLE
0066 preact-iso を導入して /sessions ページへのルーティング基盤を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [ADD] preact-iso を導入して /sessions ページへのルーティング基盤を追加する
+  - @voluntas
+
 ### misc
 
 - [ADD] e2e テストに Page Object Model と環境変数読み込みヘルパーを導入する

--- a/issues/closed/0066-add-preact-iso-routing.md
+++ b/issues/closed/0066-add-preact-iso-routing.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-24
-- Completed: YYYY-MM-DD
+- Completed: 2026-07-10
 - Model: GLM-5.2
 - Branch: feature/add-preact-iso-routing
 - Polished: 2026-07-10
@@ -135,35 +135,12 @@ LocationProvider          ← main.tsx（useLocation が有効になる境界）
 
 ## 解決方法
 
-1. 失敗するテストを先に追加する（`CODEBASE.md` の「テストを先に修正すること」）
-   - `vitest.ct.config.ts` を次のように更新する
-     - `vite.config.ts` と同じ `resolve.alias["@"]` を追加する
-     - `provider: playwright({ contextOptions: { permissions: ["clipboard-read", "clipboard-write"] } })` を設定する（ct はブラウザ内実行のため E2E の `context.grantPermissions` は使えない。#0038 の E2E 先例を ct に流用しない）
-   - ct 共通: 各ファイルの `afterEach`（または同等）で `setDebug(false)` / `setDebugType("timeline")`（`@/app/actions` または `@/app/signals`）と、必要なら `@/app/signals` の `resetState()`、および `history.replaceState(null, "", "/")` による pathname 復元を行い、同一 page 上の後続テスト汚染を防ぐ
-   - `src/components/Header/SessionsButton.ct.tsx`: 本番と同じ境界（`LocationProvider` 配下・ボタンは `Router` 外、`Sessions` は `Router` 内）でラップし、クリック後に `window.location.pathname === "/sessions"` かつ `getByRole("heading", { name: "Sessions" })` が出ることを検証する。history のモックは使わない
-   - LocationProvider 同期用プローブ: 各 `*.ct.tsx` 内のローカルコンポーネントとし、本番コードには残さない。`data-testid="location-probe"` で `useLocation().url` をテキスト表示する
-   - `src/components/Header/CopyUrlButton.ct.tsx`: 上記 clipboard 権限のもと Copy 成功後にプローブ URL が `pathname + search` と一致することを検証する
-   - `src/components/DebugPane/DebugPane.ct.tsx`: 描画前に本番 API の `setDebug(true)` を呼ぶ（モック禁止。`DebugButton` クリックでも可）。タブを `timeline` から `signaling` へ切り替え、プローブ URL に `debugType=signaling` が反映されることを検証する
-   - `tests/routing.test.ts`（Playwright。ルーティング遷移と接続維持の両方をこのファイルに置く）:
-     - `/` / `/devtools/` / `/devtools` で `button[name="connect"]` が見えること
-     - `getByRole("button", { name: "Sessions" })` クリックで `/sessions` に遷移し、`getByRole("heading", { name: "Sessions" })` が見えること
-     - `/sessions` 直アクセスで仮ページが表示されること
-     - 既存 query（`channelId` 等）が `/` で復元されること
-     - 接続維持（`#0037` → `#0063` ハード前提。`requireSoraConnectionEnv()` + `#0037` の `DevtoolsPage` で接続・connectionId 取得。`process.env` フォールバック禁止。Sessions 遷移は POM に未実装なら `page` の locator を併用し、必要なら `DevtoolsPage` にメソッドを足す）:
-       1. `DevtoolsPage` の起点 URL（`/devtools/`）で接続し、`#local-video-connection-id` のテキストをキャプチャする
-       2. Header の TURN URL（`page.locator("header p")`。現状 Header 内の `<p>` は TURN のみ）が `"TURN URL"` 以外になるまで待つ（`connectionStatus === "connected"` 到達。connection-id 出現時点ではまだ `"connecting"` のことがある）
-       3. `getByRole("button", { name: "Sessions" })` で `/sessions` へ遷移する（`#local-video-connection-id` は DevTools アンマウントにより消える。消えること自体は切断を意味しない）
-       4. `/sessions` 滞在中も `header p` が `"TURN URL"` ではないことを確認する（接続中は `turnUrl` または `"不明"`。Signaling URL は未接続でも candidates 表示のため使わない）
-       5. `getByRole("link", { name: "Sora DevTools" })`（NavbarBrand）で戻り、address bar の pathname が `/` であること（`/devtools/` 起点でも Brand は `href="/"` 固定。`href` を `/devtools/` に変更しない）、かつ `#local-video-connection-id` がキャプチャと一致することを確認する
-2. `package.json` の `dependencies` に `preact-iso` を追加する（`vp install` → `x.y.z` ピン留め。peer の `preact-render-to-string` が自動導入されたら同様にピン留め）
-3. `vite.config.ts` の `manualChunks` に `preact-iso` を追加する（`#0058` 未マージ時は `preact-iso` を `preact` より先に配置）
-4. `src/main.tsx` を `render(<LocationProvider><App /></LocationProvider>, rootElement)` に変更する
-5. `src/App.tsx` を上記ツリーどおりに変更する（`import { ErrorBoundary, Router, Route, lazy } from "preact-iso"`。`beforeunload` の登録と `removeEventListener` 対称）
-6. `src/routes/Sessions.tsx` に仮ページ（`<h1>Sessions</h1>`）を作成する
-7. `SessionsButton.tsx` を作成し `Header/index.tsx` に `NavbarText` 付きで配置する
-8. `CopyUrlButton.tsx` / `DebugPane/index.tsx` で先頭 `useLocation` + ハンドラ内 `route(..., true)` を入れる
-9. `DevTools.tsx` から `Header` / `Footer` と初期化 / cleanup の `disconnectSora` を削除する
-10. `CHANGES.md` の `## develop` に ADD エントリを追記する（`shiguredo-changelog` に従い、エントリ直後に `- @username` を付ける）
+1. `preact-iso` 2.12.0 を導入し、`main.tsx` に `LocationProvider`、`App.tsx` に `Router` / `Route` / `lazy(Sessions)` / `ErrorBoundary` と `beforeunload` による切断ライフサイクルを実装した
+2. `DevTools.tsx` から `Header` / `Footer` と初期化・`disconnectSora` cleanup を除去し、`SessionsButton` と `src/routes/Sessions.tsx` 仮ページを追加した
+3. `CopyUrlButton` / `DebugPane` で `history.replaceState` 後に `route(..., true)` を呼び、`LocationProvider` と address bar を同期した
+4. `vite.config.ts` の `manualChunks` に `preact-iso` を `preact` より先に追加した
+5. ct テスト 3 件 (`SessionsButton` / `CopyUrlButton` / `DebugPane`) と E2E `tests/routing.test.ts` を追加した
+6. `vp check` / `vp test run` / `pnpm test:ct` / `pnpm test:e2e` / `vp build` で確認した
 
 ## 関連 issue
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@shiguredo/noise-suppression": "2025.1.0",
     "@shiguredo/virtual-background": "2023.2.0",
     "preact": "10.29.3",
+    "preact-iso": "2.12.0",
     "sora-js-sdk": "2026.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       preact:
         specifier: 10.29.3
         version: 10.29.3
+      preact-iso:
+        specifier: 2.12.0
+        version: 2.12.0(preact-render-to-string@6.7.0(preact@10.29.3))(preact@10.29.3)
       sora-js-sdk:
         specifier: 2026.1.0
         version: 2026.1.0
@@ -1410,6 +1413,17 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  preact-iso@2.12.0:
+    resolution: {integrity: sha512-k0Y44UONBJ1zBXXCBhJRAa5O4ww8a5FHdLD6l21IxcnsTmDBto4n7KPQAH6xqegsKDMX4SuJ02qItiUlciIlZQ==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+      preact-render-to-string: '>=6.4.0'
+
+  preact-render-to-string@6.7.0:
+    resolution: {integrity: sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+
   preact@10.29.3:
     resolution: {integrity: sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==}
 
@@ -2711,6 +2725,15 @@ snapshots:
       nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-iso@2.12.0(preact-render-to-string@6.7.0(preact@10.29.3))(preact@10.29.3):
+    dependencies:
+      preact: 10.29.3
+      preact-render-to-string: 6.7.0(preact@10.29.3)
+
+  preact-render-to-string@6.7.0(preact@10.29.3):
+    dependencies:
+      preact: 10.29.3
 
   preact@10.29.3: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,48 @@
+import { useEffect } from "preact/hooks";
+import { ErrorBoundary, lazy, Route, Router } from "preact-iso";
+
+import {
+  disconnectSora,
+  setInitialParameter,
+  setMediaDevices,
+  unregisterServiceWorker,
+} from "@/app/actions";
+import { Footer } from "@/components/Footer";
+import { Header } from "@/components/Header";
+
 import DevTools from "./DevTools.tsx";
 
+const Sessions = lazy(async () => import("./routes/Sessions.tsx"));
+
+// タブ閉鎖・リロード時に Sora 切断を試行する
+function handleBeforeUnload(): void {
+  void disconnectSora();
+}
+
 function App() {
-  return <DevTools />;
+  useEffect(() => {
+    void setInitialParameter();
+    void setMediaDevices();
+    void unregisterServiceWorker();
+    globalThis.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      globalThis.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+
+  return (
+    <>
+      <Header />
+      <ErrorBoundary>
+        <Router>
+          <Route path="/" component={DevTools} />
+          <Route path="/sessions" component={Sessions} />
+          <Route default component={DevTools} />
+        </Router>
+      </ErrorBoundary>
+      <Footer />
+    </>
+  );
 }
 
 export default App;

--- a/src/DevTools.tsx
+++ b/src/DevTools.tsx
@@ -1,38 +1,16 @@
-import { useEffect } from "preact/hooks";
-
-import {
-  disconnectSora,
-  setInitialParameter,
-  setMediaDevices,
-  unregisterServiceWorker,
-} from "@/app/actions";
 import { DebugPane } from "@/components/DebugPane";
 import { DevtoolsPane } from "@/components/DevtoolsPane";
-import { Footer } from "@/components/Footer";
-import { Header } from "@/components/Header";
 
 function Devtools() {
-  useEffect(() => {
-    void setInitialParameter();
-    void setMediaDevices();
-    void unregisterServiceWorker();
-    return () => {
-      void disconnectSora();
-    };
-  }, []);
   return (
-    <>
-      <Header />
-      <main>
-        <div className="container">
-          <div className="row">
-            <DevtoolsPane />
-            <DebugPane />
-          </div>
+    <main>
+      <div className="container">
+        <div className="row">
+          <DevtoolsPane />
+          <DebugPane />
         </div>
-      </main>
-      <Footer />
-    </>
+      </div>
+    </main>
   );
 }
 

--- a/src/components/DebugPane/DebugPane.ct.tsx
+++ b/src/components/DebugPane/DebugPane.ct.tsx
@@ -1,0 +1,50 @@
+import { LocationProvider, useLocation } from "preact-iso";
+import { afterEach, assert, test, vi } from "vite-plus/test";
+import { render } from "vitest-browser-preact";
+
+import { setDebug, setDebugType } from "@/app/actions";
+import { resetState } from "@/app/signals";
+
+import { DebugPane } from "./index";
+
+// LocationProvider の内部 state を検証するためのローカルプローブ
+function LocationProbe() {
+  const { url } = useLocation();
+  return <div data-testid="location-probe">{url}</div>;
+}
+
+function DebugPaneHarness() {
+  return (
+    <LocationProvider>
+      <LocationProbe />
+      <DebugPane />
+    </LocationProvider>
+  );
+}
+
+afterEach(() => {
+  setDebug(false);
+  setDebugType("timeline");
+  resetState();
+  globalThis.history.replaceState(null, "", "/");
+});
+
+test("DebugPane: タブ切替後に LocationProvider の url に debugType が反映される", async () => {
+  setDebug(true);
+  setDebugType("timeline");
+  globalThis.history.replaceState(null, "", "/?debug=true");
+
+  const screen = render(<DebugPaneHarness />);
+
+  await screen.getByRole("tab", { name: "Signaling" }).click();
+
+  const probe = screen.getByTestId("location-probe");
+
+  await vi.waitFor(
+    () => {
+      const { textContent } = probe.element();
+      assert.include(textContent, "debugType=signaling");
+    },
+    { timeout: 5000 },
+  );
+});

--- a/src/components/DebugPane/index.tsx
+++ b/src/components/DebugPane/index.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from "preact-iso";
 import { Tab, Tabs } from "@/components/ui";
 
 import { setDebugType } from "@/app/actions";
@@ -18,6 +19,7 @@ import { Stats } from "./Stats.tsx";
 import { TimelineMessages } from "./TimelineMessages.tsx";
 
 export function DebugPane() {
+  const { route } = useLocation();
   const debugValue = debug.value;
   const debugTypeValue = debugType.value;
   if (!debugValue) {
@@ -41,6 +43,7 @@ export function DebugPane() {
       searchParams.set("debugType", key);
       const newUrl = `${location.pathname}?${searchParams.toString()}`;
       globalThis.history.replaceState(null, "", newUrl);
+      route(`${location.pathname}?${searchParams.toString()}`, true);
     }
   };
   return (

--- a/src/components/Header/CopyUrlButton.ct.tsx
+++ b/src/components/Header/CopyUrlButton.ct.tsx
@@ -1,0 +1,49 @@
+import { LocationProvider, useLocation } from "preact-iso";
+import { afterEach, assert, test, vi } from "vite-plus/test";
+import { render } from "vitest-browser-preact";
+
+import { setChannelId, setDebug, setDebugType } from "@/app/actions";
+import { resetState } from "@/app/signals";
+
+import { CopyUrlButton } from "./CopyUrlButton";
+
+// LocationProvider の内部 state を検証するためのローカルプローブ
+function LocationProbe() {
+  const { url } = useLocation();
+  return <div data-testid="location-probe">{url}</div>;
+}
+
+function CopyUrlHarness() {
+  return (
+    <LocationProvider>
+      <LocationProbe />
+      <CopyUrlButton />
+    </LocationProvider>
+  );
+}
+
+afterEach(() => {
+  setDebug(false);
+  setDebugType("timeline");
+  resetState();
+  globalThis.history.replaceState(null, "", "/");
+});
+
+test("CopyUrlButton: コピー成功後に LocationProvider の url が address bar と一致する", async () => {
+  setChannelId("test-channel");
+  globalThis.history.replaceState(null, "", "/");
+
+  const screen = render(<CopyUrlHarness />);
+
+  await screen.getByRole("button", { name: "Copy URL" }).click();
+
+  const expectedUrl = `${globalThis.location.pathname}${globalThis.location.search}`;
+  const probe = screen.getByTestId("location-probe");
+
+  await vi.waitFor(
+    () => {
+      assert.equal(probe.element().textContent, expectedUrl);
+    },
+    { timeout: 5000 },
+  );
+});

--- a/src/components/Header/CopyUrlButton.tsx
+++ b/src/components/Header/CopyUrlButton.tsx
@@ -1,15 +1,18 @@
 import { useSignal } from "@preact/signals";
+import { useLocation } from "preact-iso";
 
 import { copyURL } from "@/app/actions";
 
 export function CopyUrlButton() {
   const copied = useSignal(false);
+  const { route } = useLocation();
 
   const onClick = async (): Promise<void> => {
     const success = await copyURL();
     if (!success) {
       return;
     }
+    route(`${globalThis.location.pathname}${globalThis.location.search}`, true);
     copied.value = true;
     setTimeout(() => {
       copied.value = false;

--- a/src/components/Header/SessionsButton.ct.tsx
+++ b/src/components/Header/SessionsButton.ct.tsx
@@ -1,0 +1,46 @@
+import { ErrorBoundary, LocationProvider, Route, Router } from "preact-iso";
+import { afterEach, assert, test, vi } from "vite-plus/test";
+import { render } from "vitest-browser-preact";
+
+import { setDebug, setDebugType } from "@/app/actions";
+import { resetState } from "@/app/signals";
+import Sessions from "@/routes/Sessions";
+
+import { SessionsButton } from "./SessionsButton";
+
+// 本番と同じ境界: LocationProvider 配下でボタンは Router 外、Sessions は Router 内
+function RoutingHarness() {
+  return (
+    <LocationProvider>
+      <SessionsButton />
+      <ErrorBoundary>
+        <Router>
+          {/* @ts-expect-error preact-iso Route の型定義が JSX 戻り値と不一致 */}
+          <Route path="/sessions" component={Sessions} />
+        </Router>
+      </ErrorBoundary>
+    </LocationProvider>
+  );
+}
+
+afterEach(() => {
+  setDebug(false);
+  setDebugType("timeline");
+  resetState();
+  globalThis.history.replaceState(null, "", "/");
+});
+
+test("SessionsButton: クリックで /sessions に遷移し仮ページを表示する", async () => {
+  const screen = render(<RoutingHarness />);
+
+  await screen.getByRole("button", { name: "Sessions" }).click();
+
+  assert.equal(globalThis.location.pathname, "/sessions");
+
+  await vi.waitFor(
+    () => {
+      assert.isNotNull(screen.getByRole("heading", { name: "Sessions" }).element());
+    },
+    { timeout: 5000 },
+  );
+});

--- a/src/components/Header/SessionsButton.tsx
+++ b/src/components/Header/SessionsButton.tsx
@@ -1,0 +1,24 @@
+import { useLocation } from "preact-iso";
+
+export function SessionsButton() {
+  const { route } = useLocation();
+
+  const onClick = (): void => {
+    route("/sessions");
+  };
+
+  const baseClasses = `
+    ml-1 w-[85px] px-2 py-1 text-sm rounded
+    font-normal leading-normal text-center no-underline align-middle
+    cursor-pointer select-none border
+    transition-colors duration-150
+  `;
+  const stateClasses =
+    "text-black bg-bs-light border-bs-light hover:bg-[#e2e6ea] hover:border-[#dae0e5]";
+
+  return (
+    <button type="button" className={`${baseClasses} ${stateClasses}`} onClick={onClick}>
+      Sessions
+    </button>
+  );
+}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -7,6 +7,7 @@ import { Navbar, NavbarBrand, NavbarCollapse, NavbarText, NavbarToggle } from "@
 import { CopyUrlButton } from "./CopyUrlButton.tsx";
 import { DebugButton } from "./DebugButton.tsx";
 import { DownloadReportButton } from "./DownloadReportButton.tsx";
+import { SessionsButton } from "./SessionsButton.tsx";
 import { SignalingUrlModal } from "./SignalingUrlModal.tsx";
 
 export function Header() {
@@ -72,6 +73,9 @@ export function Header() {
               </NavbarText>
               <NavbarText className="py-0 my-1 mx-1">
                 <DownloadReportButton />
+              </NavbarText>
+              <NavbarText className="py-0 my-1 mx-1">
+                <SessionsButton />
               </NavbarText>
               <NavbarText className="py-0 my-1 ml-1">
                 <CopyUrlButton />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { render } from "preact";
+import { LocationProvider } from "preact-iso";
 import "./App.css";
 import App from "./App.tsx";
 
@@ -8,4 +9,9 @@ if (!rootElement) {
   throw new Error("Root element not found");
 }
 
-render(<App />, rootElement);
+render(
+  <LocationProvider>
+    <App />
+  </LocationProvider>,
+  rootElement,
+);

--- a/src/routes/Sessions.tsx
+++ b/src/routes/Sessions.tsx
@@ -1,0 +1,5 @@
+import type { FunctionComponent } from "preact";
+
+const Sessions: FunctionComponent = () => <h1>Sessions</h1>;
+
+export default Sessions;

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,0 +1,102 @@
+import { test } from "@playwright/test";
+
+import { requireSoraConnectionEnv } from "./helpers/env.ts";
+import { DevtoolsPage } from "./pages/DevtoolsPage.ts";
+
+const BASE_URL = "http://localhost:3333";
+const CONNECT_BUTTON_SELECTOR = 'button[name="connect"]';
+
+test("ルーティング: / /devtools/ /devtools で DevTools が表示される", async ({ page }) => {
+  await page.goto(`${BASE_URL}/`);
+  await page.locator(CONNECT_BUTTON_SELECTOR).waitFor({ timeout: 5000 });
+
+  await page.goto(`${BASE_URL}/devtools/`);
+  await page.locator(CONNECT_BUTTON_SELECTOR).waitFor({ timeout: 5000 });
+
+  await page.goto(`${BASE_URL}/devtools`);
+  await page.locator(CONNECT_BUTTON_SELECTOR).waitFor({ timeout: 5000 });
+});
+
+test("ルーティング: Sessions ボタンで /sessions に遷移する", async ({ page }) => {
+  await page.goto(`${BASE_URL}/devtools/`);
+
+  await page.getByRole("button", { name: "Sessions" }).click();
+  await page.getByRole("heading", { name: "Sessions" }).waitFor({ timeout: 5000 });
+  const pathname = await page.evaluate(() => globalThis.location.pathname);
+  if (pathname !== "/sessions") {
+    throw new Error(`expected pathname "/sessions", got "${pathname}"`);
+  }
+});
+
+test("ルーティング: /sessions 直アクセスで仮ページが表示される", async ({ page }) => {
+  await page.goto(`${BASE_URL}/sessions`);
+  await page.getByRole("heading", { name: "Sessions" }).waitFor({ timeout: 5000 });
+});
+
+test("ルーティング: 既存 query が / で復元される", async ({ page }) => {
+  const devtools = new DevtoolsPage(page);
+  const channelId = "routing-test-channel";
+
+  await devtools.navigate({
+    role: "sendrecv",
+    channelId,
+    signalingUrlCandidates: ["wss://example.example.com/signaling"],
+    accessToken: "test-token",
+  });
+
+  const channelIdInput = page.getByRole("textbox", { name: "ChannelIdを指定" });
+  await channelIdInput.waitFor({ timeout: 10_000 });
+  const value = await channelIdInput.inputValue();
+  if (value !== channelId) {
+    throw new Error(`expected channelId input value "${channelId}", got "${value}"`);
+  }
+});
+
+test("ルーティング: SPA 遷移中も Sora 接続が維持される", async ({ page }) => {
+  const env = requireSoraConnectionEnv();
+  const devtools = new DevtoolsPage(page);
+
+  await devtools.navigate({
+    role: "sendrecv",
+    channelId: `${env.channelIdPrefix}routing-maintain`,
+    signalingUrlCandidates: [env.signalingUrl],
+    accessToken: env.accessToken,
+    videoCodecType: "VP9",
+  });
+
+  await devtools.connect();
+  await devtools.waitForConnection();
+
+  const connectionId = await devtools.getConnectionId();
+  if (connectionId === null || connectionId === "") {
+    throw new Error("expected non-empty connection ID before SPA navigation");
+  }
+
+  const turnUrlLabel = page.locator("header p");
+  await turnUrlLabel.waitFor({ timeout: 10_000 });
+  const connectedTurnLabel = await turnUrlLabel.textContent();
+  if (connectedTurnLabel === "TURN URL") {
+    throw new Error('expected TURN URL label to change from "TURN URL" after connection');
+  }
+
+  await page.getByRole("button", { name: "Sessions" }).click();
+  await page.getByRole("heading", { name: "Sessions" }).waitFor({ timeout: 5000 });
+
+  const sessionsTurnLabel = await turnUrlLabel.textContent();
+  if (sessionsTurnLabel === "TURN URL") {
+    throw new Error(
+      'expected connection to remain active on /sessions, but TURN URL label is "TURN URL"',
+    );
+  }
+
+  await page.getByRole("link", { name: "Sora DevTools" }).click();
+  await page.waitForURL((url) => url.pathname === "/", { timeout: 5000 });
+
+  await devtools.waitForConnection();
+  const restoredConnectionId = await devtools.getConnectionId();
+  if (restoredConnectionId !== connectionId) {
+    throw new Error(
+      `expected connection ID "${connectionId}" after returning to /, got "${restoredConnectionId ?? ""}"`,
+    );
+  }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       output: {
         manualChunks(moduleId) {
           const chunks: Record<string, string[]> = {
+            "preact-iso": ["preact-iso"],
             preact: ["preact"],
             "mp4-media-stream": ["@shiguredo/mp4-media-stream"],
             "noise-suppression": ["@shiguredo/noise-suppression"],

--- a/vitest.ct.config.ts
+++ b/vitest.ct.config.ts
@@ -1,10 +1,18 @@
+import path from "node:path";
 import preactPlugin from "@preact/preset-vite";
 import tailwindcss from "@tailwindcss/vite";
 import { playwright } from "vite-plus/test/browser/providers/playwright";
 import { defineConfig } from "vite-plus/test/config";
 
+const rootDir = import.meta.dirname;
+
 export default defineConfig({
   plugins: [preactPlugin(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(rootDir, "./src"),
+    },
+  },
   optimizeDeps: {
     include: ["vitest-browser-preact"],
   },
@@ -15,7 +23,11 @@ export default defineConfig({
     setupFiles: ["vitest-browser-preact"],
     browser: {
       enabled: true,
-      provider: playwright(),
+      provider: playwright({
+        contextOptions: {
+          permissions: ["clipboard-read", "clipboard-write"],
+        },
+      }),
       headless: true,
       instances: [{ browser: "chromium", headless: true }],
     },


### PR DESCRIPTION
## 概要

過去セッション一覧ページ `/sessions` の前提となる preact-iso ルーティング基盤を導入する。SPA 遷移で Sora 接続が切れないよう、初期化と切断ライフサイクルを `App.tsx` に集約する。

## 変更内容

- `preact-iso` を導入し、`/` / `/sessions` / 未知パス（`/devtools/` 等）のルーティングを追加
- `SessionsButton` と仮 `Sessions` ページを追加
- `CopyUrlButton` / `DebugPane` で `history.replaceState` 後に `route(..., true)` を呼び `LocationProvider` を同期
- `App.tsx` に初期化 3 関数と `beforeunload` 切断を移し、`DevTools` アンマウント時は切断しない
- ct テスト 3 件と `tests/routing.test.ts` E2E を追加

## 完了条件

- [x] `/` / `/devtools/` / `/devtools` で既存 DevTools が動作する
- [x] `/sessions` で仮ページが表示される
- [x] `Sessions` ボタンでクライアントサイド遷移できる
- [x] NavbarBrand で `/` に戻り接続が維持される
- [x] `CopyUrlButton` / DebugPane タブ切替後に `useLocation().url` が address bar と一致する
- [x] 既存クエリストリングが `/` で復元される
- [x] SPA 遷移中に Sora 接続が切断されない
- [x] `manualChunks` で `preact-iso` が独立 chunk になる
- [x] `vp build` / `vp test run` / `pnpm test:ct` / `pnpm test:e2e` / `vp check` が成功する
- [x] `CHANGES.md` に ADD エントリを追記した

## 関連 issue

- issues/closed/0066-add-preact-iso-routing.md