### PR TITLE
0068 WebRTC stats を DuckDB-Wasm + OPFS に永続化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [ADD] WebRTC stats を DuckDB-Wasm + OPFS に永続化する
+  - @voluntas
 - [ADD] DuckDB-Wasm + OPFS でセッション・接続メタデータを永続化する
   - @voluntas
 - [ADD] preact-iso を導入して /sessions ページへのルーティング基盤を追加する

--- a/issues/closed/0068-add-webrtc-stats-persistence.md
+++ b/issues/closed/0068-add-webrtc-stats-persistence.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-24
-- Completed: YYYY-MM-DD
+- Completed: 2026-07-11
 - Model: GLM-5.2
 - Branch: feature/add-webrtc-stats-persistence
 - Polished: 2026-07-11
@@ -172,17 +172,16 @@ Medium。接続品質や帯域・パケットロスなどの時系列変化を�
 
 ## 解決方法
 
-1. `src/sessionDatabase.ts` の `createSchema` に `seq_webrtc_stats_id` / `webrtc_stats` / `session_db_id` INDEX を追加する
-2. `src/webrtcStatsNormalizer.ts` を作成し、正規化関数と `NormalizedWebrtcStat` を実装する
-3. `sessionDatabase` に `enqueueStats` / `flushStatsBuffer` / `clearStatsBuffers`（`sessionDbId` 必須）とバッチ・再試行・サンプリングを実装する。DuckDB 操作はすべて `enqueueWrite` 経由。失敗は `notifyPersistenceError`
-4. `SessionPersistenceState` に Sora `sessionId` を追加し、`connection.created` で同期セットする
-5. `setStatsReportInternal(soraConnection, persistence)` / `startStatsReportTimer(soraConnection, persistence)` に persistence を渡し、正規化 → `enqueueStats` を fire-and-forget する。`connectSora` / `reconnectSoraImpl` の呼び出し箇所を更新する
-6. `disconnect` フックでは `isCurrent()` **前**に `flushStatsBuffer(persistence.sessionDbId)` のみ（クロージャの id。`getCurrentSessionDbId()` 禁止）。`stopStatsReportTimer` は `isCurrent()` **後**のまま
-7. `disconnectSora` 先頭で `getCurrentSessionDbId()` をキャプチャして void flush する（`beforeunload` 経路）。`close()` は追加しない
-8. `abortConnectSoraResources` / 失敗明示パスでも当該 `persistence.sessionDbId` を flush する
-9. 新接続試行開始時に旧 id のバッファを clear しない（切断側 flush に任せる）
-10. Playwright E2E と Vitest / fixture を追加する（テスト方針どおり）
-11. `App.tsx` は変更対象外（`createSessionDatabase` は #0067 済み）
+1. `src/sessionDatabase.ts` の `createSchema` に `seq_webrtc_stats_id` / `webrtc_stats` / `session_db_id` INDEX を追加した
+2. `src/webrtcStatsNormalizer.ts` を作成し、正規化関数・`NormalizedWebrtcStat`・サンプリング選択を実装した
+3. `sessionDatabase` に `enqueueStats` / `flushStatsBuffer` / `clearStatsBuffers` とバッチ・再試行・サンプリングを実装した。DuckDB 操作は `enqueueWrite` 経由
+4. `SessionPersistenceState` に Sora `sessionId` を追加し、`connection.created` で同期セットした
+5. `setStatsReportInternal` / `startStatsReportTimer` に persistence を渡し、正規化 → `enqueueStats` を fire-and-forget した
+6. `disconnect` フックでは `isCurrent()` 前に `flushStatsBuffer(persistence.sessionDbId)`、`stopStatsReportTimer` は後のままにした
+7. `disconnectSora` 先頭で `getCurrentSessionDbId()` をキャプチャして void flush した。`beforeunload` では `close()` を呼ばない方針のまま。E2E 用 `close()` は未 flush の stats を先に書き出してからハンドルを解放する
+8. abort / 失敗明示パスでも当該 `sessionDbId` を flush した
+9. Vitest（fixture: inbound/outbound/candidate-pair/transport/codec）と Playwright E2E（`tests/webrtc-stats-persistence.test.ts`）を追加した
+10. `CHANGES.md` の `## develop` に `[ADD]` を追記した
 
 ## テスト方針
 

--- a/src/__fixtures__/webrtc-stats-sample.json
+++ b/src/__fixtures__/webrtc-stats-sample.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "IT01",
+    "timestamp": 1000.5,
+    "type": "inbound-rtp",
+    "kind": "video",
+    "ssrc": 1234567890,
+    "packetsReceived": 100,
+    "packetsLost": 1,
+    "bytesReceived": 50000,
+    "framesReceived": 30,
+    "frameWidth": 640,
+    "frameHeight": 360,
+    "framesPerSecond": 30,
+    "googJitterBufferMs": 10
+  },
+  {
+    "id": "OT01",
+    "timestamp": 1000.5,
+    "type": "outbound-rtp",
+    "kind": "audio",
+    "ssrc": 987654321,
+    "packetsSent": 80,
+    "bytesSent": 12000,
+    "headerBytesSent": 400,
+    "retransmittedPacketsSent": 0,
+    "retransmittedBytesSent": 0,
+    "totalPacketSendDelay": 0.01,
+    "nackCount": 0
+  },
+  {
+    "id": "CP01",
+    "timestamp": 1000.5,
+    "type": "candidate-pair",
+    "state": "succeeded",
+    "nominated": true,
+    "roundTripTime": 0.02,
+    "totalRoundTripTime": 1.5,
+    "availableOutgoingBitrate": 1000000,
+    "availableIncomingBitrate": 900000,
+    "localCandidateId": "L1",
+    "remoteCandidateId": "R1",
+    "bytesSent": 1000,
+    "bytesReceived": 2000
+  },
+  {
+    "id": "T01",
+    "timestamp": 1000.5,
+    "type": "transport",
+    "selectedCandidatePairId": "CP01",
+    "bytesSent": 3000,
+    "bytesReceived": 4000
+  },
+  {
+    "id": "C01",
+    "timestamp": 1000.5,
+    "type": "codec",
+    "mimeType": "video/VP9",
+    "clockRate": 90000,
+    "payloadType": 98
+  }
+]

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -39,6 +39,8 @@ import {
 } from "./../noiseSuppression.ts";
 import { loadUrlEntries } from "./../opfs.ts";
 import {
+  enqueueStats,
+  flushStatsBuffer,
   getCurrentConnectionId,
   getCurrentSessionDbId,
   insertConnection,
@@ -47,6 +49,7 @@ import {
   updateSessionEndedAt,
   updateSessionIdAndConnectionId,
 } from "./../sessionDatabase.ts";
+import { normalizeWebrtcStats } from "./../webrtcStatsNormalizer.ts";
 import * as signals from "./signals.ts";
 
 // 接続試行単位の永続化コンテキスト。sessions.id はローカルで保持し、
@@ -57,6 +60,8 @@ interface SessionPersistenceState {
   // connection.created 時点の connectionId。SDK は disconnect コールバック前に
   // soraConnection.connectionId を null 化するため、フックではこの値を優先する
   observedConnectionId: string | null;
+  // connection.created 時点の Sora session_id（stats 行用。signals は読まない）
+  sessionId: string | null;
   // disconnect が INSERT より先に来た connectionId を記録し、INSERT 完了後に ended_at を書く
   connectionEndedPendingIds: Set<string>;
 }
@@ -101,6 +106,16 @@ function connectionIdFromPersistence(
     return null;
   }
   return persistence.persistedConnectionId ?? persistence.observedConnectionId;
+}
+
+// stats バッファを fire-and-forget で flush する（DuckDB への書き込み）
+function persistStatsFlush(sessionDbId: number | null | undefined): void {
+  if (sessionDbId === null || sessionDbId === undefined) {
+    return;
+  }
+  runPersistenceTask(async () => {
+    await flushStatsBuffer(sessionDbId);
+  });
 }
 
 // クエリストリングのパラメータを各 signal に設定する
@@ -1057,6 +1072,7 @@ function handleConnectionCreatedNotify(
       const connectionId = message.connection_id;
       // SDK が disconnect 前に connectionId を消す前に、同期で保持する
       persistence.observedConnectionId = connectionId;
+      persistence.sessionId = sessionId;
       const soraClientId = typeof message.client_id === "string" ? message.client_id : "";
       const channelId = signals.channelId.value;
       const signalingUrl = soraConnection.connectedSignalingUrl;
@@ -1339,6 +1355,8 @@ function setSoraCallbacks(
     if (current && !reconnecting) {
       persistSessionEndedAt(sessionDbIdForPersistence);
     }
+    // stats バッファは isCurrent 前に、クロージャの sessionDbId で flush する
+    persistStatsFlush(sessionDbIdForPersistence);
     // 以降の state 操作は新セッションのみ
     if (!current) {
       return;
@@ -1498,9 +1516,12 @@ function createSoraDevtoolsMediaStreamTrackLog(
   return createSoraDevtoolsTimelineMessage(`${action}-${track.kind}-mediastream-track`, properties);
 }
 
-// statsReport を更新
+// statsReport を更新し、永続化バッファへ正規化結果を積む
+// channelId を渡した場合は開始時キャプチャ値を使い、毎 tick の signals 参照を避ける
 async function setStatsReportInternal(
   soraConnection: ConnectionPublisher | ConnectionSubscriber,
+  persistence: SessionPersistenceState | null,
+  channelId?: string,
 ): Promise<void> {
   // 前行の soraConnection.pc && で null チェック済みのため ?. は冗長
   if (soraConnection.pc && soraConnection.pc.iceConnectionState !== "closed") {
@@ -1524,6 +1545,24 @@ async function setStatsReportInternal(
         signals.setSoraTurnUrl(localCandidate.url);
         break;
       }
+    }
+
+    if (persistence !== null) {
+      const resolvedChannelId = channelId ?? signals.channelId.value;
+      const normalized = normalizeWebrtcStats(
+        statsReportData,
+        persistence.sessionDbId,
+        persistence.sessionId,
+        persistence.observedConnectionId ?? persistence.persistedConnectionId,
+        resolvedChannelId,
+      );
+      enqueueStats(
+        normalized,
+        persistence.sessionDbId,
+        persistence.sessionId,
+        persistence.observedConnectionId ?? persistence.persistedConnectionId,
+        resolvedChannelId,
+      );
     }
   }
 }
@@ -1671,21 +1710,27 @@ function stopStatsReportTimer(): void {
   }
 }
 
-function startStatsReportTimer(): void {
+function startStatsReportTimer(
+  soraConnection: ConnectionPublisher | ConnectionSubscriber,
+  persistence: SessionPersistenceState | null,
+): void {
   // 既存タイマーがあれば停止してから起動する。再接続のたびにタイマーが増殖するのを防ぐ
   stopStatsReportTimer();
+  // 開始時に persistence / connection / channelId をキャプチャする（毎 tick の getCurrent は使わない）
+  const capturedPersistence = persistence;
+  const capturedConnection = soraConnection;
+  const capturedChannelId = signals.channelId.value;
   const schedule = async (): Promise<void> => {
-    const soraValue = signals.sora.value;
-    if (!soraValue) {
+    if (signals.sora.value !== capturedConnection) {
       statsReportTimerId = null;
       return;
     }
     try {
-      await setStatsReportInternal(soraValue);
+      await setStatsReportInternal(capturedConnection, capturedPersistence, capturedChannelId);
     } catch {
       // getStats のエラーはタイマーを停止させない
     }
-    if (signals.sora.value !== null) {
+    if (signals.sora.value === capturedConnection) {
       statsReportTimerId = setTimeout(() => {
         void schedule();
       }, 1000);
@@ -1766,6 +1811,7 @@ export const connectSora = async (): Promise<void> => {
           sessionDbId,
           persistedConnectionId: null,
           observedConnectionId: null,
+          sessionId: null,
           connectionEndedPendingIds: new Set(),
         };
   let soraConnection: undefined | ConnectionPublisher | ConnectionSubscriber;
@@ -1795,6 +1841,7 @@ export const connectSora = async (): Promise<void> => {
     // sessions / connections の ended_at は明示パスで更新する。
     persistSessionEndedAt(persistence?.sessionDbId);
     persistConnectionEndedAt(connectionIdFromPersistence(persistence));
+    persistStatsFlush(persistence?.sessionDbId);
     return true;
   };
   try {
@@ -1847,6 +1894,7 @@ export const connectSora = async (): Promise<void> => {
     // try/catch 失敗時は明示パスで ended_at を更新する
     persistSessionEndedAt(persistence?.sessionDbId);
     persistConnectionEndedAt(connectionIdFromPersistence(persistence));
+    persistStatsFlush(persistence?.sessionDbId);
     await cleanupMediaStreamOnError(state, mediaStream);
     // 残留した remoteClients と localMediaStream を掃除し、接続失敗後も UI に映像が残らないようにする
     await cleanupSoraMediaState();
@@ -1855,13 +1903,13 @@ export const connectSora = async (): Promise<void> => {
   }
   // createSoraConnectionByRole は常に ConnectionPublisher | ConnectionSubscriber を返すため soraConnection は non-null
   signals.setSoraInfoAlertMessage("succeeded to connect Sora");
-  await setStatsReportInternal(soraConnection);
+  await setStatsReportInternal(soraConnection, persistence);
   // 検知ポイント 5: setStatsReportInternal の await 中にも Disconnect が押されうるため、
   // setSoraConnectionStatus("connected") を立てる前に最終チェックする
   if (abortIfCancelled()) {
     return;
   }
-  startStatsReportTimer();
+  startStatsReportTimer(soraConnection, persistence);
   if (mediaStream && (localMediaStreamValue === null || forceCreateMediaStream)) {
     signals.setLocalMediaStream(mediaStream);
   }
@@ -1893,6 +1941,7 @@ async function attemptReconnection(
     if (persistence !== null) {
       persistence.persistedConnectionId = null;
       persistence.observedConnectionId = null;
+      persistence.sessionId = null;
     }
     let soraConnection: undefined | ConnectionPublisher | ConnectionSubscriber;
     try {
@@ -1923,6 +1972,7 @@ async function attemptReconnection(
       // リトライ途中の catch では sessions.ended_at は更新しない。
       // connections INSERT 済みならその connectionId で ended_at を更新する。
       persistConnectionEndedAt(connectionIdFromPersistence(persistence));
+      persistStatsFlush(persistence?.sessionDbId);
       soraConnection = undefined;
     }
     if (soraConnection !== undefined) {
@@ -1959,6 +2009,7 @@ const reconnectSoraImpl = async (): Promise<void> => {
           sessionDbId,
           persistedConnectionId: null,
           observedConnectionId: null,
+          sessionId: null,
           connectionEndedPendingIds: new Set(),
         };
   let mediaStream: undefined | MediaStream;
@@ -1977,6 +2028,7 @@ const reconnectSoraImpl = async (): Promise<void> => {
       }
       persistSessionEndedAt(persistence?.sessionDbId);
       persistConnectionEndedAt(connectionIdFromPersistence(persistence));
+      persistStatsFlush(persistence?.sessionDbId);
       await cleanupSoraMediaState();
       signals.setSoraConnectionStatus("disconnected");
       signals.setSoraReconnecting(false);
@@ -2014,6 +2066,7 @@ const reconnectSoraImpl = async (): Promise<void> => {
     // 全リトライ枯渇 / reconnecting キャンセル時は明示パスで sessions.ended_at を更新する
     persistSessionEndedAt(persistence?.sessionDbId);
     persistConnectionEndedAt(connectionIdFromPersistence(persistence));
+    persistStatsFlush(persistence?.sessionDbId);
     await cleanupSoraMediaState();
     signals.setSoraErrorAlertMessage("failed to reconnect Sora");
     signals.setSoraConnectionStatus("disconnected");
@@ -2021,8 +2074,8 @@ const reconnectSoraImpl = async (): Promise<void> => {
     return;
   }
   signals.setSoraInfoAlertMessage("succeeded to reconnect Sora");
-  await setStatsReportInternal(soraConnection);
-  startStatsReportTimer();
+  await setStatsReportInternal(soraConnection, persistence);
+  startStatsReportTimer(soraConnection, persistence);
   signals.setSora(soraConnection);
   if (mediaStream) {
     signals.setLocalMediaStream(mediaStream);
@@ -2066,6 +2119,8 @@ export const disconnectSora = async (): Promise<void> => {
   const connectionIdToEnd = getCurrentConnectionId();
   persistSessionEndedAt(sessionDbIdToEnd);
   persistConnectionEndedAt(connectionIdToEnd);
+  // stats も先頭で flush する（beforeunload の fire-and-forget を空洞化しない）
+  persistStatsFlush(sessionDbIdToEnd);
   // (2) reconnecting 中ならリトライを止める（early return で setSoraReconnecting(false) に届かないため）
   if (signals.reconnecting.value) {
     signals.setSoraReconnecting(false);

--- a/src/sessionDatabase.ts
+++ b/src/sessionDatabase.ts
@@ -5,6 +5,8 @@ import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 
 import { setSoraErrorAlertMessage } from "@/app/signals";
 import type { Json } from "@/types";
+import { selectIdsToDeleteForSampling } from "@/webrtcStatsNormalizer";
+import type { NormalizedWebrtcStat } from "@/webrtcStatsNormalizer";
 
 // OPFS 上の DuckDB データベースパス（signaling-url-candidates.json と衝突しない名前）
 const OPFS_DB_PATH = "opfs://sora-devtools-sessions.db";
@@ -43,6 +45,21 @@ let lastAlertAt = 0;
 let initStarted = false;
 // AsyncDuckDBConnection は同一接続への並行 query を想定しないため、書き込みを直列化する
 let writeChain: Promise<void> = Promise.resolve();
+
+// webrtc_stats バッチ用。session_db_id 単位のバッファ
+const STATS_FLUSH_COUNT = 1000;
+const STATS_FLUSH_INTERVAL_MS = 5000;
+const STATS_SOFT_LIMIT = 10_000;
+const STATS_MAX_RETRIES = 3;
+
+interface StatsBufferState {
+  rows: NormalizedWebrtcStat[];
+  firstEnqueueAt: number | null;
+  flushTimerId: ReturnType<typeof setTimeout> | null;
+  retryCount: number;
+}
+
+const statsBuffers = new Map<number, StatsBufferState>();
 
 // whenReady() 用の共有 Promise。成功・失敗いずれでも settle する
 let readyResolve: (() => void) | null = null;
@@ -259,6 +276,55 @@ async function createSchema(connection: AsyncDuckDBConnection): Promise<void> {
       ended_at TIMESTAMP,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
+  `);
+  await connection.query("CREATE SEQUENCE IF NOT EXISTS seq_webrtc_stats_id");
+  await connection.query(`
+    CREATE TABLE IF NOT EXISTS webrtc_stats (
+      id BIGINT PRIMARY KEY DEFAULT nextval('seq_webrtc_stats_id'),
+      session_db_id INTEGER,
+      session_id VARCHAR,
+      connection_id VARCHAR,
+      channel_id VARCHAR,
+      timestamp_ms DOUBLE,
+      stats_type VARCHAR,
+      stats_id VARCHAR,
+      kind VARCHAR,
+      ssrc UBIGINT,
+      track_identifier VARCHAR,
+      transport_id VARCHAR,
+      codec_id VARCHAR,
+      mid VARCHAR,
+      remote_id VARCHAR,
+      packets_received BIGINT,
+      packets_lost BIGINT,
+      packets_sent BIGINT,
+      bytes_received BIGINT,
+      bytes_sent BIGINT,
+      header_bytes_sent BIGINT,
+      retransmitted_packets_sent BIGINT,
+      retransmitted_bytes_sent BIGINT,
+      total_packet_send_delay DOUBLE,
+      nack_count BIGINT,
+      frame_width INTEGER,
+      frame_height INTEGER,
+      frames_per_second DOUBLE,
+      frames_received BIGINT,
+      round_trip_time DOUBLE,
+      total_round_trip_time DOUBLE,
+      available_outgoing_bitrate DOUBLE,
+      available_incoming_bitrate DOUBLE,
+      local_candidate_id VARCHAR,
+      remote_candidate_id VARCHAR,
+      candidate_pair_state VARCHAR,
+      nominated BOOLEAN,
+      selected_candidate_pair_id VARCHAR,
+      raw_json JSON,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+  await connection.query(`
+    CREATE INDEX IF NOT EXISTS idx_webrtc_stats_session_db_id
+    ON webrtc_stats(session_db_id)
   `);
 }
 
@@ -587,6 +653,8 @@ export async function updateConnectionEndedAt(connectionId: string): Promise<voi
 // 公式 OPFS テストの close 手順に合わせ、再 open 可能な状態でハンドルを解放する
 export async function close(): Promise<void> {
   stopCheckpointTimer();
+  // E2E の list 経路が close するため、未 flush の stats を先に書き出してから解放する
+  await flushStatsBuffer();
   // 進行中の書き込みを待ってからハンドルを解放する
   await enqueueWrite(async () => {
     const connection = duckdbConnection;
@@ -597,6 +665,12 @@ export async function close(): Promise<void> {
     currentConnectionId = null;
     // 同一ドキュメントで再初期化できるようにする（whenReady は settle 済みのまま）
     initStarted = false;
+    for (const buffer of statsBuffers.values()) {
+      if (buffer.flushTimerId !== null) {
+        clearTimeout(buffer.flushTimerId);
+      }
+    }
+    statsBuffers.clear();
 
     if (connection !== null) {
       try {
@@ -642,6 +716,276 @@ export async function close(): Promise<void> {
       }
     }
   });
+}
+
+function getOrCreateStatsBuffer(sessionDbId: number): StatsBufferState {
+  const existing = statsBuffers.get(sessionDbId);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const created: StatsBufferState = {
+    rows: [],
+    firstEnqueueAt: null,
+    flushTimerId: null,
+    retryCount: 0,
+  };
+  statsBuffers.set(sessionDbId, created);
+  return created;
+}
+
+function scheduleStatsFlush(sessionDbId: number): void {
+  const buffer = statsBuffers.get(sessionDbId);
+  if (buffer === undefined || buffer.flushTimerId !== null) {
+    return;
+  }
+  buffer.flushTimerId = setTimeout(() => {
+    buffer.flushTimerId = null;
+    void flushStatsBuffer(sessionDbId);
+  }, STATS_FLUSH_INTERVAL_MS);
+}
+
+// 正規化済み stats を session_db_id 単位バッファへ追加する
+export function enqueueStats(
+  normalizedStats: NormalizedWebrtcStat[],
+  sessionDbId: number,
+  sessionId: string | null,
+  connectionId: string | null,
+  channelId: string,
+): void {
+  if (normalizedStats.length === 0) {
+    return;
+  }
+  if (duckdbConnection === null && !initStarted) {
+    warnUnavailable("enqueueStats");
+    return;
+  }
+  const buffer = getOrCreateStatsBuffer(sessionDbId);
+  for (const row of normalizedStats) {
+    buffer.rows.push({
+      ...row,
+      session_db_id: sessionDbId,
+      session_id: sessionId,
+      connection_id: connectionId,
+      channel_id: channelId,
+    });
+  }
+  if (buffer.firstEnqueueAt === null) {
+    buffer.firstEnqueueAt = Date.now();
+    scheduleStatsFlush(sessionDbId);
+  }
+  if (buffer.rows.length >= STATS_FLUSH_COUNT) {
+    void flushStatsBuffer(sessionDbId);
+  }
+}
+
+async function insertStatsRowsUnlocked(rows: NormalizedWebrtcStat[]): Promise<void> {
+  if (duckdbConnection === null || rows.length === 0) {
+    return;
+  }
+  const statement = await duckdbConnection.prepare(`
+    INSERT INTO webrtc_stats (
+      session_db_id, session_id, connection_id, channel_id, timestamp_ms,
+      stats_type, stats_id, kind, ssrc, track_identifier, transport_id, codec_id,
+      mid, remote_id, packets_received, packets_lost, packets_sent, bytes_received,
+      bytes_sent, header_bytes_sent, retransmitted_packets_sent, retransmitted_bytes_sent,
+      total_packet_send_delay, nack_count, frame_width, frame_height, frames_per_second,
+      frames_received, round_trip_time, total_round_trip_time, available_outgoing_bitrate,
+      available_incoming_bitrate, local_candidate_id, remote_candidate_id,
+      candidate_pair_state, nominated, selected_candidate_pair_id, raw_json
+    ) VALUES (
+      ?, ?, ?, ?, ?,
+      ?, ?, ?, ?, ?, ?, ?,
+      ?, ?, ?, ?, ?, ?,
+      ?, ?, ?, ?,
+      ?, ?, ?, ?, ?,
+      ?, ?, ?, ?,
+      ?, ?, ?,
+      ?, ?, ?, CAST(? AS JSON)
+    )
+  `);
+  try {
+    for (const row of rows) {
+      await statement.query(
+        row.session_db_id,
+        row.session_id,
+        row.connection_id,
+        row.channel_id,
+        row.timestamp_ms,
+        row.stats_type,
+        row.stats_id,
+        row.kind,
+        row.ssrc,
+        row.track_identifier,
+        row.transport_id,
+        row.codec_id,
+        row.mid,
+        row.remote_id,
+        row.packets_received,
+        row.packets_lost,
+        row.packets_sent,
+        row.bytes_received,
+        row.bytes_sent,
+        row.header_bytes_sent,
+        row.retransmitted_packets_sent,
+        row.retransmitted_bytes_sent,
+        row.total_packet_send_delay,
+        row.nack_count,
+        row.frame_width,
+        row.frame_height,
+        row.frames_per_second,
+        row.frames_received,
+        row.round_trip_time,
+        row.total_round_trip_time,
+        row.available_outgoing_bitrate,
+        row.available_incoming_bitrate,
+        row.local_candidate_id,
+        row.remote_candidate_id,
+        row.candidate_pair_state,
+        row.nominated,
+        row.selected_candidate_pair_id,
+        JSON.stringify(row.raw_json),
+      );
+    }
+  } finally {
+    await statement.close();
+  }
+}
+
+function isPermanentStatsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+  return lower.includes("quota") || lower.includes("enospc") || lower.includes("quotaexceeded");
+}
+
+async function applyStatsSamplingUnlocked(sessionDbId: number): Promise<void> {
+  if (duckdbConnection === null) {
+    return;
+  }
+  const countTable = await duckdbConnection.query(
+    `SELECT COUNT(*) AS count FROM webrtc_stats WHERE session_db_id = ${sessionDbId}`,
+  );
+  const countColumn = countTable.getChildAt(0);
+  const rawCount: unknown = countColumn === null ? 0 : countColumn.get(0);
+  let count = 0;
+  if (typeof rawCount === "bigint") {
+    count = Number(rawCount);
+  } else if (typeof rawCount === "number") {
+    count = rawCount;
+  }
+  if (count <= STATS_SOFT_LIMIT) {
+    return;
+  }
+  const idTable = await duckdbConnection.query(
+    `SELECT id, timestamp_ms FROM webrtc_stats WHERE session_db_id = ${sessionDbId}`,
+  );
+  const idColumn = idTable.getChildAt(0);
+  const tsColumn = idTable.getChildAt(1);
+  if (idColumn === null || tsColumn === null) {
+    return;
+  }
+  const rows: Array<{ id: number; timestamp_ms: number }> = [];
+  for (let index = 0; index < idColumn.length; index += 1) {
+    const rawId: unknown = idColumn.get(index);
+    const rawTs: unknown = tsColumn.get(index);
+    let id = 0;
+    let timestampMs = 0;
+    if (typeof rawId === "bigint") {
+      id = Number(rawId);
+    } else if (typeof rawId === "number") {
+      id = rawId;
+    }
+    if (typeof rawTs === "number") {
+      timestampMs = rawTs;
+    }
+    rows.push({ id, timestamp_ms: timestampMs });
+  }
+  const toDelete = selectIdsToDeleteForSampling(rows, STATS_SOFT_LIMIT);
+  if (toDelete.length === 0) {
+    return;
+  }
+  // id リストを分割して DELETE する
+  const chunkSize = 500;
+  for (let offset = 0; offset < toDelete.length; offset += chunkSize) {
+    const chunk = toDelete.slice(offset, offset + chunkSize);
+    const list = chunk.join(",");
+    await duckdbConnection.query(`DELETE FROM webrtc_stats WHERE id IN (${list})`);
+  }
+}
+
+async function flushOneStatsBuffer(targetId: number, buffer: StatsBufferState): Promise<void> {
+  if (buffer.rows.length === 0) {
+    return;
+  }
+  if (buffer.flushTimerId !== null) {
+    clearTimeout(buffer.flushTimerId);
+    buffer.flushTimerId = null;
+  }
+  const { rows } = buffer;
+  buffer.rows = [];
+  buffer.firstEnqueueAt = null;
+  await enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      warnUnavailable("flushStatsBuffer");
+      // close 済みで map から外れている場合は orphan 復元しない
+      if (!statsBuffers.has(targetId)) {
+        return;
+      }
+      buffer.rows = [...rows, ...buffer.rows];
+      scheduleStatsFlush(targetId);
+      return;
+    }
+    try {
+      await insertStatsRowsUnlocked(rows);
+      await applyStatsSamplingUnlocked(targetId);
+      await runCheckpointUnlocked();
+      buffer.retryCount = 0;
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? `Failed to flush webrtc stats: ${error.message}`
+          : "Failed to flush webrtc stats";
+      console.warn(message);
+      notifyPersistenceError(message);
+      if (isPermanentStatsError(error) || buffer.retryCount >= STATS_MAX_RETRIES) {
+        buffer.retryCount = 0;
+        return;
+      }
+      buffer.retryCount += 1;
+      buffer.rows = [...rows, ...buffer.rows];
+      scheduleStatsFlush(targetId);
+    }
+  });
+}
+
+// バッファをバルク INSERT する。sessionDbId 省略時は全バッファ
+export async function flushStatsBuffer(sessionDbId?: number): Promise<void> {
+  let targets: number[];
+  if (sessionDbId === undefined) {
+    targets = [...statsBuffers.keys()];
+  } else if (statsBuffers.has(sessionDbId)) {
+    targets = [sessionDbId];
+  } else {
+    targets = [];
+  }
+  for (const targetId of targets) {
+    const buffer = statsBuffers.get(targetId);
+    if (buffer === undefined) {
+      continue;
+    }
+    await flushOneStatsBuffer(targetId, buffer);
+  }
+}
+
+// 指定 session_db_id のバッファを破棄する（flush せず捨ててよい場合のみ）
+export function clearStatsBuffers(sessionDbId: number): void {
+  const buffer = statsBuffers.get(sessionDbId);
+  if (buffer === undefined) {
+    return;
+  }
+  if (buffer.flushTimerId !== null) {
+    clearTimeout(buffer.flushTimerId);
+  }
+  statsBuffers.delete(sessionDbId);
 }
 
 // E2E 専用: アプリ側 close 済み前提で OPFS DB を一時 open して SQL を実行する

--- a/src/webrtcStatsNormalizer.test.ts
+++ b/src/webrtcStatsNormalizer.test.ts
@@ -1,0 +1,116 @@
+import { assert, test } from "vite-plus/test";
+
+import fixtureStats from "./__fixtures__/webrtc-stats-sample.json";
+import {
+  buildRawJson,
+  normalizeWebrtcStats,
+  selectIdsToDeleteForSampling,
+} from "./webrtcStatsNormalizer.ts";
+
+function requireRow(
+  rows: ReturnType<typeof normalizeWebrtcStats>,
+  statsType: string,
+): ReturnType<typeof normalizeWebrtcStats>[number] {
+  const row = rows.find((candidate) => candidate.stats_type === statsType);
+  assert.ok(row, `stats_type=${statsType} の行が必要`);
+  return row;
+}
+
+function requireRawObject(raw: unknown): Record<string, unknown> {
+  assert.equal(typeof raw, "object");
+  assert.notEqual(raw, null);
+  assert.equal(Array.isArray(raw), false);
+  return raw as Record<string, unknown>;
+}
+
+// 正規化対象 type の主要フィールドがカラムに入り、goog* は raw_json に残る
+test("normalizeWebrtcStats は inbound-rtp を正規化し goog 拡張を raw_json に残す", () => {
+  const normalized = normalizeWebrtcStats(fixtureStats, 1, "sid", "cid", "channel");
+  const inbound = requireRow(normalized, "inbound-rtp");
+  assert.equal(inbound.session_db_id, 1);
+  assert.equal(inbound.session_id, "sid");
+  assert.equal(inbound.connection_id, "cid");
+  assert.equal(inbound.channel_id, "channel");
+  assert.equal(inbound.kind, "video");
+  assert.equal(inbound.packets_received, 100);
+  assert.equal(inbound.frame_width, 640);
+  const raw = requireRawObject(inbound.raw_json);
+  assert.equal(raw.googJitterBufferMs, 10);
+  assert.equal(raw.packetsReceived, undefined);
+  assert.equal(raw.type, undefined);
+});
+
+// outbound-rtp の送信系フィールドがカラムに入り raw_json に重複しない
+test("normalizeWebrtcStats は outbound-rtp を正規化する", () => {
+  const normalized = normalizeWebrtcStats(fixtureStats, 1, "sid", "cid", "channel");
+  const outbound = requireRow(normalized, "outbound-rtp");
+  assert.equal(outbound.kind, "audio");
+  assert.equal(outbound.packets_sent, 80);
+  assert.equal(outbound.bytes_sent, 12_000);
+  assert.equal(outbound.header_bytes_sent, 400);
+  assert.equal(outbound.total_packet_send_delay, 0.01);
+  const raw = requireRawObject(outbound.raw_json);
+  assert.equal(raw.packetsSent, undefined);
+  assert.equal(raw.bytesSent, undefined);
+});
+
+// candidate-pair の RTT / bitrate / nominated がカラムに入り raw_json に重複しない
+test("normalizeWebrtcStats は candidate-pair を正規化する", () => {
+  const normalized = normalizeWebrtcStats(fixtureStats, 1, "sid", "cid", "channel");
+  const pair = requireRow(normalized, "candidate-pair");
+  assert.equal(pair.candidate_pair_state, "succeeded");
+  assert.equal(pair.nominated, true);
+  assert.equal(pair.round_trip_time, 0.02);
+  assert.equal(pair.available_outgoing_bitrate, 1_000_000);
+  assert.equal(pair.local_candidate_id, "L1");
+  const raw = requireRawObject(pair.raw_json);
+  assert.equal(raw.state, undefined);
+  assert.equal(raw.nominated, undefined);
+  assert.equal(raw.roundTripTime, undefined);
+});
+
+// transport の selectedCandidatePairId がカラムに入り raw_json に重複しない
+test("normalizeWebrtcStats は transport を正規化する", () => {
+  const normalized = normalizeWebrtcStats(fixtureStats, 1, "sid", "cid", "channel");
+  const transport = requireRow(normalized, "transport");
+  assert.equal(transport.selected_candidate_pair_id, "CP01");
+  assert.equal(transport.bytes_sent, 3000);
+  const raw = requireRawObject(transport.raw_json);
+  assert.equal(raw.selectedCandidatePairId, undefined);
+  assert.equal(raw.bytesSent, undefined);
+});
+
+// codec は正規化対象外でも 1 行として残り、mimeType は raw_json に入る
+test("normalizeWebrtcStats は codec を raw_json 中心の行として残す", () => {
+  const normalized = normalizeWebrtcStats(fixtureStats, 1, null, null, "channel");
+  const codec = requireRow(normalized, "codec");
+  assert.equal(codec.session_id, null);
+  assert.equal(codec.packets_received, null);
+  const raw = requireRawObject(codec.raw_json);
+  assert.equal(raw.mimeType, "video/VP9");
+});
+
+// buildRawJson は正規化キーを除外する
+test("buildRawJson は正規化カラムキーを除外する", () => {
+  const raw = buildRawJson({
+    type: "inbound-rtp",
+    id: "x",
+    timestamp: 1,
+    packetsReceived: 1,
+    customField: "keep",
+  });
+  assert.deepEqual(raw, { customField: "keep" });
+});
+
+// サンプリング: 新しい 10000 を残し、古い側は 10 件に 1 件
+test("selectIdsToDeleteForSampling は古い側を 10 件に 1 件残す", () => {
+  const rows = [];
+  for (let index = 0; index < 20_000; index += 1) {
+    rows.push({ id: index + 1, timestamp_ms: index });
+  }
+  const toDelete = selectIdsToDeleteForSampling(rows, 10_000);
+  // 古い 10000 件のうち index%10!==0 が削除 → 9000 件削除
+  assert.equal(toDelete.length, 9000);
+  assert.ok(!toDelete.includes(1));
+  assert.ok(toDelete.includes(2));
+});

--- a/src/webrtcStatsNormalizer.ts
+++ b/src/webrtcStatsNormalizer.ts
@@ -1,0 +1,300 @@
+// RTCStats を webrtc_stats テーブル向けに正規化する純粋関数群
+// 参照: WebRTC Statistics API (W3C) https://www.w3.org/TR/webrtc-stats/
+
+import type { Json } from "@/types";
+
+// 第 1 段階で正規化カラムに展開する type
+const NORMALIZED_STATS_TYPES = new Set([
+  "inbound-rtp",
+  "outbound-rtp",
+  "remote-inbound-rtp",
+  "remote-outbound-rtp",
+  "candidate-pair",
+  "transport",
+]);
+
+// 正規化カラム名（テーブル定義と 1:1。raw_json から除外するキーの正規化名）
+const NORMALIZED_COLUMN_KEYS = [
+  "timestamp",
+  "type",
+  "id",
+  "kind",
+  "ssrc",
+  "trackIdentifier",
+  "transportId",
+  "codecId",
+  "mid",
+  "remoteId",
+  "packetsReceived",
+  "packetsLost",
+  "packetsSent",
+  "bytesReceived",
+  "bytesSent",
+  "headerBytesSent",
+  "retransmittedPacketsSent",
+  "retransmittedBytesSent",
+  "totalPacketSendDelay",
+  "nackCount",
+  "frameWidth",
+  "frameHeight",
+  "framesPerSecond",
+  "framesReceived",
+  "roundTripTime",
+  "totalRoundTripTime",
+  "availableOutgoingBitrate",
+  "availableIncomingBitrate",
+  "localCandidateId",
+  "remoteCandidateId",
+  "state",
+  "nominated",
+  "selectedCandidatePairId",
+] as const;
+
+const NORMALIZED_COLUMN_KEY_SET = new Set<string>(NORMALIZED_COLUMN_KEYS);
+
+// webrtc_stats 行（id / created_at を除く）に対応する正規化結果
+export interface NormalizedWebrtcStat {
+  session_db_id: number;
+  session_id: string | null;
+  connection_id: string | null;
+  channel_id: string;
+  timestamp_ms: number;
+  stats_type: string;
+  stats_id: string;
+  kind: string | null;
+  ssrc: number | null;
+  track_identifier: string | null;
+  transport_id: string | null;
+  codec_id: string | null;
+  mid: string | null;
+  remote_id: string | null;
+  packets_received: number | null;
+  packets_lost: number | null;
+  packets_sent: number | null;
+  bytes_received: number | null;
+  bytes_sent: number | null;
+  header_bytes_sent: number | null;
+  retransmitted_packets_sent: number | null;
+  retransmitted_bytes_sent: number | null;
+  total_packet_send_delay: number | null;
+  nack_count: number | null;
+  frame_width: number | null;
+  frame_height: number | null;
+  frames_per_second: number | null;
+  frames_received: number | null;
+  round_trip_time: number | null;
+  total_round_trip_time: number | null;
+  available_outgoing_bitrate: number | null;
+  available_incoming_bitrate: number | null;
+  local_candidate_id: string | null;
+  remote_candidate_id: string | null;
+  candidate_pair_state: string | null;
+  nominated: boolean | null;
+  selected_candidate_pair_id: string | null;
+  raw_json: Json;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  if (typeof value === "string") {
+    return value;
+  }
+  return null;
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return null;
+}
+
+function readBoolean(record: Record<string, unknown>, key: string): boolean | null {
+  const value = record[key];
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return null;
+}
+
+function optionalString(
+  enabled: boolean,
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  if (!enabled) {
+    return null;
+  }
+  return readString(record, key);
+}
+
+function optionalNumber(
+  enabled: boolean,
+  record: Record<string, unknown>,
+  key: string,
+): number | null {
+  if (!enabled) {
+    return null;
+  }
+  return readNumber(record, key);
+}
+
+function optionalBoolean(
+  enabled: boolean,
+  record: Record<string, unknown>,
+  key: string,
+): boolean | null {
+  if (!enabled) {
+    return null;
+  }
+  return readBoolean(record, key);
+}
+
+// 正規化カラムに含まれるキーを除いた残りを raw_json にする
+export function buildRawJson(stat: Record<string, unknown>): Json {
+  const raw: Record<string, Json | undefined> = {};
+  for (const [key, value] of Object.entries(stat)) {
+    if (NORMALIZED_COLUMN_KEY_SET.has(key)) {
+      continue;
+    }
+    if (value === undefined) {
+      continue;
+    }
+    if (
+      value === null ||
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      raw[key] = value;
+      continue;
+    }
+    if (typeof value === "object") {
+      raw[key] = value as Json;
+    }
+  }
+  return raw;
+}
+
+// 1 件の RTCStats 相当オブジェクトを正規化する
+export function normalizeOneWebrtcStat(
+  stat: unknown,
+  sessionDbId: number,
+  sessionId: string | null,
+  connectionId: string | null,
+  channelId: string,
+): NormalizedWebrtcStat | null {
+  const record = asRecord(stat);
+  if (record === null) {
+    return null;
+  }
+  const statsType = readString(record, "type");
+  const statsId = readString(record, "id");
+  const timestampMs = readNumber(record, "timestamp");
+  if (statsType === null || statsId === null || timestampMs === null) {
+    return null;
+  }
+
+  // 正規化対象外 type も raw_json 中心で 1 行として残す（一覧・件数検証のため）
+  const enabled = NORMALIZED_STATS_TYPES.has(statsType);
+
+  return {
+    session_db_id: sessionDbId,
+    session_id: sessionId,
+    connection_id: connectionId,
+    channel_id: channelId,
+    timestamp_ms: timestampMs,
+    stats_type: statsType,
+    stats_id: statsId,
+    kind: optionalString(enabled, record, "kind"),
+    ssrc: optionalNumber(enabled, record, "ssrc"),
+    track_identifier: optionalString(enabled, record, "trackIdentifier"),
+    transport_id: optionalString(enabled, record, "transportId"),
+    codec_id: optionalString(enabled, record, "codecId"),
+    mid: optionalString(enabled, record, "mid"),
+    remote_id: optionalString(enabled, record, "remoteId"),
+    packets_received: optionalNumber(enabled, record, "packetsReceived"),
+    packets_lost: optionalNumber(enabled, record, "packetsLost"),
+    packets_sent: optionalNumber(enabled, record, "packetsSent"),
+    bytes_received: optionalNumber(enabled, record, "bytesReceived"),
+    bytes_sent: optionalNumber(enabled, record, "bytesSent"),
+    header_bytes_sent: optionalNumber(enabled, record, "headerBytesSent"),
+    retransmitted_packets_sent: optionalNumber(enabled, record, "retransmittedPacketsSent"),
+    retransmitted_bytes_sent: optionalNumber(enabled, record, "retransmittedBytesSent"),
+    total_packet_send_delay: optionalNumber(enabled, record, "totalPacketSendDelay"),
+    nack_count: optionalNumber(enabled, record, "nackCount"),
+    frame_width: optionalNumber(enabled, record, "frameWidth"),
+    frame_height: optionalNumber(enabled, record, "frameHeight"),
+    frames_per_second: optionalNumber(enabled, record, "framesPerSecond"),
+    frames_received: optionalNumber(enabled, record, "framesReceived"),
+    round_trip_time: optionalNumber(enabled, record, "roundTripTime"),
+    total_round_trip_time: optionalNumber(enabled, record, "totalRoundTripTime"),
+    available_outgoing_bitrate: optionalNumber(enabled, record, "availableOutgoingBitrate"),
+    available_incoming_bitrate: optionalNumber(enabled, record, "availableIncomingBitrate"),
+    local_candidate_id: optionalString(enabled, record, "localCandidateId"),
+    remote_candidate_id: optionalString(enabled, record, "remoteCandidateId"),
+    candidate_pair_state: optionalString(enabled, record, "state"),
+    nominated: optionalBoolean(enabled, record, "nominated"),
+    selected_candidate_pair_id: optionalString(enabled, record, "selectedCandidatePairId"),
+    raw_json: buildRawJson(record),
+  };
+}
+
+// RTCStats 配列を正規化する
+export function normalizeWebrtcStats(
+  stats: unknown[],
+  sessionDbId: number,
+  sessionId: string | null,
+  connectionId: string | null,
+  channelId: string,
+): NormalizedWebrtcStat[] {
+  const result: NormalizedWebrtcStat[] = [];
+  for (const stat of stats) {
+    const normalized = normalizeOneWebrtcStat(
+      stat,
+      sessionDbId,
+      sessionId,
+      connectionId,
+      channelId,
+    );
+    if (normalized !== null) {
+      result.push(normalized);
+    }
+  }
+  return result;
+}
+
+// 容量サンプリング: timestamp_ms 昇順の古い側から 10 件に 1 件残す対象 id を返す
+export function selectIdsToDeleteForSampling(
+  rows: Array<{ id: number; timestamp_ms: number }>,
+  keepNewestCount: number,
+): number[] {
+  if (rows.length <= keepNewestCount) {
+    return [];
+  }
+  const sorted = [...rows].toSorted((left, right) => {
+    if (left.timestamp_ms !== right.timestamp_ms) {
+      return left.timestamp_ms - right.timestamp_ms;
+    }
+    return left.id - right.id;
+  });
+  const oldCount = sorted.length - keepNewestCount;
+  const oldRows = sorted.slice(0, oldCount);
+  const toDelete: number[] = [];
+  for (let index = 0; index < oldRows.length; index += 1) {
+    // 10 件ごとに 1 件残す（index % 10 === 0 を残す）
+    if (index % 10 === 0) {
+      continue;
+    }
+    toDelete.push(oldRows[index].id);
+  }
+  return toDelete;
+}

--- a/tests/helpers/sessionDatabase.ts
+++ b/tests/helpers/sessionDatabase.ts
@@ -146,3 +146,75 @@ export async function waitForEndedAt(
       `(session=${String(lastSession?.ended_at)}, connection=${String(lastConnection?.ended_at)})`,
   );
 }
+
+// webrtc_stats 行の最小形状
+export interface WebrtcStatsRow {
+  id: number;
+  session_db_id: number;
+  session_id: string | null;
+  connection_id: string | null;
+  channel_id: string | null;
+  stats_type: string | null;
+}
+
+// webrtc_stats 全行を取得する
+export async function listWebrtcStatsRows(page: Page): Promise<WebrtcStatsRow[]> {
+  return querySessionDatabase<WebrtcStatsRow>(
+    page,
+    "SELECT id, session_db_id, session_id, connection_id, channel_id, stats_type FROM webrtc_stats ORDER BY id",
+  );
+}
+
+// 切断後の flush 反映を待つ（DuckDB 上の件数）
+export async function waitForWebrtcStats(
+  page: Page,
+  options: {
+    connectionId?: string;
+    sessionDbId?: number;
+    channelId?: string;
+    minCount?: number;
+    timeoutMs?: number;
+  },
+): Promise<WebrtcStatsRow[]> {
+  if (options.connectionId === undefined && options.sessionDbId === undefined) {
+    throw new Error("waitForWebrtcStats requires connectionId or sessionDbId");
+  }
+  const minCount = options.minCount ?? 1;
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const deadline = Date.now() + timeoutMs;
+  let matched: WebrtcStatsRow[] = [];
+
+  while (Date.now() < deadline) {
+    // 明示 flush（切断フックの fire-and-forget を補完する）
+    await page.evaluate(async (moduleUrl) => {
+      const loaded: unknown = await import(/* @vite-ignore */ moduleUrl);
+      const mod = loaded as {
+        flushStatsBuffer: () => Promise<void>;
+      };
+      await mod.flushStatsBuffer();
+    }, SESSION_DATABASE_MODULE_URL);
+    const rows = await listWebrtcStatsRows(page);
+    matched = rows.filter((row) => {
+      if (options.connectionId !== undefined && row.connection_id !== options.connectionId) {
+        return false;
+      }
+      if (options.sessionDbId !== undefined && row.session_db_id !== options.sessionDbId) {
+        return false;
+      }
+      if (options.channelId !== undefined && row.channel_id !== options.channelId) {
+        return false;
+      }
+      return true;
+    });
+    if (matched.length >= minCount) {
+      return matched;
+    }
+    await page.waitForTimeout(200);
+  }
+
+  throw new Error(
+    `webrtc_stats count was below ${minCount} within ${timeoutMs}ms ` +
+      `(got ${matched.length} for connectionId=${String(options.connectionId)} ` +
+      `sessionDbId=${String(options.sessionDbId)})`,
+  );
+}

--- a/tests/webrtc-stats-persistence.test.ts
+++ b/tests/webrtc-stats-persistence.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+
+import { requireSoraConnectionEnv } from "./helpers/env.ts";
+import {
+  awaitSessionDatabaseReady,
+  cleanupSessionDatabase,
+  listWebrtcStatsRows,
+  waitForEndedAt,
+  waitForWebrtcStats,
+} from "./helpers/sessionDatabase.ts";
+import { DevtoolsPage } from "./pages/DevtoolsPage.ts";
+
+// OPFS 上の DB はオリジン共有のため、永続化テスト同士の並列実行を禁止する
+test.describe.configure({ mode: "serial" });
+
+test.describe("webrtc stats persistence", () => {
+  test.beforeEach(async ({ page }) => {
+    await cleanupSessionDatabase(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupSessionDatabase(page);
+  });
+
+  test("切断後に webrtc_stats が DuckDB へ保存されリロード後も残る", async ({ page }) => {
+    const env = requireSoraConnectionEnv();
+    const channelId = `${env.channelIdPrefix}session-db-stats-persist`;
+
+    const devtools = new DevtoolsPage(page);
+    await devtools.navigate({
+      role: "sendrecv",
+      channelId,
+      signalingUrlCandidates: [env.signalingUrl],
+      accessToken: env.accessToken,
+      videoCodecType: "VP9",
+    });
+    await awaitSessionDatabaseReady(page);
+
+    await devtools.connect();
+    await devtools.waitForConnection();
+    const connectionId = await devtools.getConnectionId();
+    expect(connectionId).toBeTruthy();
+    if (!connectionId) {
+      return;
+    }
+
+    // 1 秒間隔の getStats が少なくとも 1 回走る猶予
+    await page.waitForTimeout(1500);
+    await devtools.disconnect();
+    const { session, connection } = await waitForEndedAt(page, { connectionId });
+
+    const statsRows = await waitForWebrtcStats(page, {
+      connectionId,
+      sessionDbId: session.id,
+      channelId,
+      minCount: 1,
+    });
+    expect(statsRows.length).toBeGreaterThanOrEqual(1);
+    expect(statsRows.every((row) => row.session_db_id === session.id)).toBe(true);
+    expect(statsRows.every((row) => row.connection_id === connectionId)).toBe(true);
+    expect(statsRows.every((row) => row.channel_id === channelId)).toBe(true);
+    expect(statsRows.every((row) => row.stats_type !== null && row.stats_type !== "")).toBe(true);
+    // session_id は connection.session_id と一致する（null の場合は両方 null）
+    expect(statsRows.every((row) => row.session_id === connection.session_id)).toBe(true);
+
+    const beforeReloadCount = statsRows.length;
+
+    await devtools.navigate({
+      role: "sendrecv",
+      channelId,
+      signalingUrlCandidates: [env.signalingUrl],
+      accessToken: env.accessToken,
+      videoCodecType: "VP9",
+    });
+    await awaitSessionDatabaseReady(page);
+
+    const afterReload = await listWebrtcStatsRows(page);
+    const matched = afterReload.filter((row) => row.connection_id === connectionId);
+    expect(matched.length).toBeGreaterThanOrEqual(beforeReloadCount);
+  });
+});


### PR DESCRIPTION
## Summary

- WebRTC stats を DuckDB-Wasm + OPFS の `webrtc_stats` に正規化カラム付きで永続化する
- 切断時 flush・バッチ INSERT・容量サンプリング・E2E / Vitest を追加する
- E2E 用 `close()` は未 flush の stats を先に書き出してからハンドルを解放する

## Test plan

- [x] `vp check`
- [x] `vp test run`（normalizer / sessionDatabase）
- [x] Playwright chromium: `webrtc-stats-persistence` + `session-database`
- [ ] CI 通過