### PR TITLE
0070 /sessions ページに過去セッション一覧・詳細・フィルタ UI を実装する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [ADD] /sessions ページに過去セッション一覧・詳細・フィルタ UI を実装する
+  - @voluntas
 - [ADD] WebRTC stats を DuckDB-Wasm + OPFS に永続化する
   - @voluntas
 - [ADD] DuckDB-Wasm + OPFS でセッション・接続メタデータを永続化する

--- a/issues/closed/0070-add-sessions-page-ui.md
+++ b/issues/closed/0070-add-sessions-page-ui.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-24
-- Completed: YYYY-MM-DD
+- Completed: 2026-07-11
 - Model: GLM-5.2
 - Branch: feature/add-sessions-page-ui
 - Polished: 2026-07-11
@@ -247,14 +247,12 @@ WebRTC のパケット / バイト系は **累積カウンタのスナップシ�
 
 ## 解決方法
 
-1. 失敗するテストを先に追加する（`CODEBASE.md`）。モック・スタブは使わない
-   - Vitest: `deriveSessionStatus`、`parseSessionsSearchParams` / `buildSessionsSearchParams`、時系列間引き等の純粋関数
-   - Playwright: `tests/sessions-page.test.ts`（仮）を `serial` + `cleanupSessionDatabase` + `requireSoraConnectionEnv()` で追加。一覧・フィルタ・詳細・再接続区別をカバーする
-2. `sessionDatabase.ts` に `listSessions` / `getSession` / `queryStatsAggregates` / `queryStatsTimeseries` / `queryStatsPage` を実装する（読み取りも直列化キュー経由）
-3. `src/components/Sessions/` に List / Detail / Filter / StatsChart を実装する
-4. `src/routes/Sessions.tsx` を仮ページから実 UI に書き換える（`whenReady`・プライバシー文言・エラー表示を含む）
-5. 仮ページ依存の `SessionsButton.ct.tsx` / `tests/routing.test.ts` を更新する
-6. `CHANGES.md` に `[ADD]` と `- @voluntas` を追記する
+- `src/sessionDatabase.ts` に `listSessions` / `getSession` / `queryStatsAggregates` / `queryStatsTimeseries` / `queryStatsPage` を追加し、読み取りも `enqueueWrite` 経由で直列化した
+- 集計・時系列の純粋計算を `src/statsQuery.ts` に切り出し、バケット内は `stats_id` 単位の last を合算 / 平均する契約にした
+- `src/sessionStatus.ts` / `src/sessionsSearchParams.ts` で 3 状態判定と QS 読み書きを実装し Vitest した
+- `src/components/Sessions/` に Filter / List / Detail / StatsChart（SVG 自前）を追加し、`src/routes/Sessions.tsx` を実 UI に置き換えた（プライバシー文言・ページ内エラー・`whenReady` 待ちを含む）
+- `tests/sessions-page.test.ts` を追加し、一覧・フィルタ・詳細・同一 channelId の複数行区別を E2E で確認した
+- 仮ページ前提の `SessionsButton.ct.tsx` / `tests/routing.test.ts` を新 UI に追従し、`CHANGES.md` に `[ADD]` を追記した
 
 ## テスト方針
 

--- a/src/components/Header/SessionsButton.ct.tsx
+++ b/src/components/Header/SessionsButton.ct.tsx
@@ -30,7 +30,7 @@ afterEach(() => {
   globalThis.history.replaceState(null, "", "/");
 });
 
-test("SessionsButton: クリックで /sessions に遷移し仮ページを表示する", async () => {
+test("SessionsButton: クリックで /sessions に遷移し Sessions ページを表示する", async () => {
   const screen = render(<RoutingHarness />);
 
   await screen.getByRole("button", { name: "Sessions" }).click();
@@ -39,7 +39,8 @@ test("SessionsButton: クリックで /sessions に遷移し仮ページを表�
 
   await vi.waitFor(
     () => {
-      assert.isNotNull(screen.getByRole("heading", { name: "Sessions" }).element());
+      assert.isNotNull(screen.getByRole("heading", { name: "Sessions", exact: true }).element());
+      assert.isNotNull(screen.getByTestId("sessions-privacy-notice").element());
     },
     { timeout: 5000 },
   );

--- a/src/components/Sessions/SessionDetail.tsx
+++ b/src/components/Sessions/SessionDetail.tsx
@@ -1,0 +1,384 @@
+import type { FunctionComponent } from "preact";
+import { useEffect, useState } from "preact/hooks";
+
+import { StatsChart } from "@/components/Sessions/StatsChart";
+import {
+  getCurrentSessionDbId,
+  getSession,
+  queryStatsAggregates,
+  queryStatsPage,
+  queryStatsTimeseries,
+  whenReady,
+} from "@/sessionDatabase";
+import type {
+  ConnectionListRow,
+  SessionDetail as SessionDetailData,
+  StatsAggregates,
+  StatsPageResult,
+  StatsTimeseriesPoint,
+} from "@/sessionDatabase";
+import { deriveSessionStatus, sessionStatusLabel } from "@/sessionStatus";
+
+export interface SessionDetailProps {
+  sessionDbId: number | undefined;
+}
+
+function displayOrDash(value: string | number | null | undefined): string {
+  if (value === null || value === undefined || value === "") {
+    return "—";
+  }
+  return String(value);
+}
+
+function formatNullableNumber(value: number | null): string {
+  if (value === null) {
+    return "—";
+  }
+  return String(value);
+}
+
+// 詳細パネル: メタデータ・connections・stats 集計 / 時系列 / 生データ
+export const SessionDetail: FunctionComponent<SessionDetailProps> = ({ sessionDbId }) => {
+  const [detail, setDetail] = useState<SessionDetailData | null>(null);
+  const [aggregates, setAggregates] = useState<StatsAggregates | null>(null);
+  const [timeseries, setTimeseries] = useState<StatsTimeseriesPoint[]>([]);
+  const [statsPage, setStatsPage] = useState<StatsPageResult>({ rows: [], totalCount: 0 });
+  const [intervalSec, setIntervalSec] = useState<10 | 60>(10);
+  const [pageOffset, setPageOffset] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const pageLimit = 50;
+
+  useEffect(() => {
+    if (sessionDbId === undefined) {
+      setDetail(null);
+      setAggregates(null);
+      setTimeseries([]);
+      setStatsPage({ rows: [], totalCount: 0 });
+      setErrorMessage(null);
+      return;
+    }
+
+    const active = { cancelled: false };
+    setLoading(true);
+    setErrorMessage(null);
+
+    void (async () => {
+      try {
+        // 未初期化のまま getSession すると null になり「見つかりません」と誤表示される
+        await whenReady();
+        if (active.cancelled) {
+          return;
+        }
+        const loaded = await getSession(sessionDbId);
+        // oxlint-disable-next-line typescript/no-unnecessary-condition
+        if (active.cancelled) {
+          return;
+        }
+        if (loaded === null) {
+          setDetail(null);
+          setAggregates(null);
+          setTimeseries([]);
+          setStatsPage({ rows: [], totalCount: 0 });
+          setLoading(false);
+          return;
+        }
+        const [agg, series, page] = await Promise.all([
+          queryStatsAggregates(sessionDbId),
+          queryStatsTimeseries(sessionDbId, { intervalSec }),
+          queryStatsPage(sessionDbId, { limit: pageLimit, offset: pageOffset }),
+        ]);
+        // await 中に cleanup で cancelled が立つ可能性がある
+        // oxlint-disable-next-line typescript/no-unnecessary-condition
+        if (active.cancelled) {
+          return;
+        }
+        setDetail(loaded);
+        setAggregates(agg);
+        setTimeseries(series);
+        setStatsPage(page);
+        setLoading(false);
+      } catch (error) {
+        if (active.cancelled) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : "Failed to load session detail";
+        console.warn(`Session detail load failed: ${message}`);
+        setErrorMessage(message);
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      active.cancelled = true;
+    };
+  }, [sessionDbId, intervalSec, pageOffset]);
+
+  if (sessionDbId === undefined) {
+    return (
+      <p className="text-bs-secondary" data-testid="session-detail-empty">
+        一覧からセッションを選択してください
+      </p>
+    );
+  }
+
+  if (loading) {
+    return (
+      <p className="text-bs-secondary" data-testid="session-detail-loading">
+        読み込み中…
+      </p>
+    );
+  }
+
+  if (errorMessage !== null) {
+    return (
+      <div
+        className="rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800"
+        data-testid="session-detail-error"
+        role="alert"
+      >
+        詳細の読み取りに失敗しました: {errorMessage}
+      </div>
+    );
+  }
+
+  if (detail === null) {
+    return (
+      <p className="text-bs-secondary" data-testid="session-detail-missing">
+        指定されたセッションは見つかりません
+      </p>
+    );
+  }
+
+  const currentSessionDbId = getCurrentSessionDbId();
+  const status = deriveSessionStatus(
+    detail.session.ended_at,
+    detail.session.id,
+    currentSessionDbId,
+  );
+  const maxOffset = Math.max(0, statsPage.totalCount - pageLimit);
+
+  return (
+    <div data-testid="session-detail" data-session-db-id={String(detail.session.id)}>
+      <h2 className="mb-2 text-lg font-semibold">セッション詳細</h2>
+      <dl className="mb-4 grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+        <div>
+          <dt className="text-bs-secondary">sessionDbId</dt>
+          <dd className="font-mono">{detail.session.id}</dd>
+        </div>
+        <div>
+          <dt className="text-bs-secondary">状態</dt>
+          <dd>{sessionStatusLabel(status)}</dd>
+        </div>
+        <div>
+          <dt className="text-bs-secondary">channelId</dt>
+          <dd>{displayOrDash(detail.session.channel_id)}</dd>
+        </div>
+        <div>
+          <dt className="text-bs-secondary">session_id</dt>
+          <dd className="font-mono text-xs">{displayOrDash(detail.session.session_id)}</dd>
+        </div>
+        <div>
+          <dt className="text-bs-secondary">role</dt>
+          <dd>{displayOrDash(detail.session.role)}</dd>
+        </div>
+        <div>
+          <dt className="text-bs-secondary">started_at</dt>
+          <dd className="font-mono text-xs">{displayOrDash(detail.session.started_at)}</dd>
+        </div>
+        <div>
+          <dt className="text-bs-secondary">ended_at</dt>
+          <dd className="font-mono text-xs">{displayOrDash(detail.session.ended_at)}</dd>
+        </div>
+      </dl>
+
+      <h3 className="mb-2 text-base font-semibold">connections</h3>
+      <ConnectionsTable connections={detail.connections} />
+
+      <h3 className="mb-2 mt-4 text-base font-semibold">WebRTC stats 集計</h3>
+      {aggregates === null ? (
+        <p className="text-sm text-bs-secondary">集計データがありません</p>
+      ) : (
+        <dl
+          className="mb-4 grid grid-cols-2 gap-2 text-sm md:grid-cols-4"
+          data-testid="stats-aggregates"
+        >
+          <div>
+            <dt className="text-bs-secondary">packets_received</dt>
+            <dd>{formatNullableNumber(aggregates.packets_received)}</dd>
+          </div>
+          <div>
+            <dt className="text-bs-secondary">packets_sent</dt>
+            <dd>{formatNullableNumber(aggregates.packets_sent)}</dd>
+          </div>
+          <div>
+            <dt className="text-bs-secondary">packet_loss_rate</dt>
+            <dd>{formatNullableNumber(aggregates.packet_loss_rate)}</dd>
+          </div>
+          <div>
+            <dt className="text-bs-secondary">rtt_min</dt>
+            <dd>{formatNullableNumber(aggregates.rtt_min)}</dd>
+          </div>
+          <div>
+            <dt className="text-bs-secondary">rtt_max</dt>
+            <dd>{formatNullableNumber(aggregates.rtt_max)}</dd>
+          </div>
+          <div>
+            <dt className="text-bs-secondary">rtt_avg</dt>
+            <dd>{formatNullableNumber(aggregates.rtt_avg)}</dd>
+          </div>
+          <div>
+            <dt className="text-bs-secondary">bitrate_send_bps</dt>
+            <dd>{formatNullableNumber(aggregates.bitrate_send_bps)}</dd>
+          </div>
+          <div>
+            <dt className="text-bs-secondary">bitrate_recv_bps</dt>
+            <dd>{formatNullableNumber(aggregates.bitrate_recv_bps)}</dd>
+          </div>
+        </dl>
+      )}
+
+      <div className="mb-2 flex items-center gap-2">
+        <h3 className="text-base font-semibold">時系列</h3>
+        <label className="text-sm">
+          間隔
+          <select
+            className="ml-2 rounded border border-bs-secondary px-2 py-1"
+            value={String(intervalSec)}
+            data-testid="timeseries-interval"
+            onChange={(event) => {
+              const next = Number(event.currentTarget.value);
+              if (next === 10 || next === 60) {
+                setIntervalSec(next);
+              }
+            }}
+          >
+            <option value="10">10 秒</option>
+            <option value="60">1 分</option>
+          </select>
+        </label>
+      </div>
+      <div data-testid="stats-timeseries">
+        <StatsChart points={timeseries} metric="bitrate_send_bps" title="送信ビットレート (bps)" />
+        <StatsChart points={timeseries} metric="bitrate_recv_bps" title="受信ビットレート (bps)" />
+        <StatsChart points={timeseries} metric="round_trip_time" title="RTT (秒)" />
+      </div>
+
+      <h3 className="mb-2 mt-4 text-base font-semibold">生データ</h3>
+      <p className="mb-2 text-sm text-bs-secondary" data-testid="stats-page-count">
+        全 {statsPage.totalCount} 件（offset {pageOffset}）
+      </p>
+      <div className="mb-2 flex gap-2">
+        <button
+          type="button"
+          className="rounded border border-bs-secondary px-2 py-1 text-sm disabled:opacity-50"
+          disabled={pageOffset <= 0}
+          data-testid="stats-page-prev"
+          onClick={() => {
+            setPageOffset(Math.max(0, pageOffset - pageLimit));
+          }}
+        >
+          前へ
+        </button>
+        <button
+          type="button"
+          className="rounded border border-bs-secondary px-2 py-1 text-sm disabled:opacity-50"
+          disabled={pageOffset >= maxOffset}
+          data-testid="stats-page-next"
+          onClick={() => {
+            setPageOffset(Math.min(maxOffset, pageOffset + pageLimit));
+          }}
+        >
+          次へ
+        </button>
+      </div>
+      <StatsRawTable page={statsPage} />
+    </div>
+  );
+};
+
+const ConnectionsTable: FunctionComponent<{ connections: ConnectionListRow[] }> = ({
+  connections,
+}) => {
+  if (connections.length === 0) {
+    return <p className="text-sm text-bs-secondary">connections はありません</p>;
+  }
+  return (
+    <div className="overflow-x-auto" data-testid="connections-table">
+      <table className="w-full border-collapse text-left text-sm">
+        <thead>
+          <tr className="border-b border-bs-secondary">
+            <th className="px-2 py-1">connection_id</th>
+            <th className="px-2 py-1">session_id</th>
+            <th className="px-2 py-1">sora_client_id</th>
+            <th className="px-2 py-1">started_at</th>
+            <th className="px-2 py-1">ended_at</th>
+          </tr>
+        </thead>
+        <tbody>
+          {connections.map((connection) => (
+            <tr key={connection.id} className="border-b border-bs-light">
+              <td className="px-2 py-1 font-mono text-xs">
+                {displayOrDash(connection.connection_id)}
+              </td>
+              <td className="px-2 py-1 font-mono text-xs">
+                {displayOrDash(connection.session_id)}
+              </td>
+              <td className="px-2 py-1 font-mono text-xs">
+                {displayOrDash(connection.sora_client_id)}
+              </td>
+              <td className="px-2 py-1 font-mono text-xs">
+                {displayOrDash(connection.started_at)}
+              </td>
+              <td className="px-2 py-1 font-mono text-xs">{displayOrDash(connection.ended_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const StatsRawTable: FunctionComponent<{ page: StatsPageResult }> = ({ page }) => {
+  if (page.rows.length === 0) {
+    return (
+      <p className="text-sm text-bs-secondary" data-testid="stats-raw-empty">
+        生データはありません
+      </p>
+    );
+  }
+  return (
+    <div className="overflow-x-auto" data-testid="stats-raw-table">
+      <table className="w-full border-collapse text-left text-xs">
+        <thead>
+          <tr className="border-b border-bs-secondary">
+            <th className="px-2 py-1">timestamp_ms</th>
+            <th className="px-2 py-1">stats_type</th>
+            <th className="px-2 py-1">stats_id</th>
+            <th className="px-2 py-1">kind</th>
+            <th className="px-2 py-1">packets_received</th>
+            <th className="px-2 py-1">packets_sent</th>
+            <th className="px-2 py-1">bytes_received</th>
+            <th className="px-2 py-1">bytes_sent</th>
+            <th className="px-2 py-1">round_trip_time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {page.rows.map((row) => (
+            <tr key={row.id} className="border-b border-bs-light">
+              <td className="px-2 py-1 font-mono">{displayOrDash(row.timestamp_ms)}</td>
+              <td className="px-2 py-1">{displayOrDash(row.stats_type)}</td>
+              <td className="px-2 py-1 font-mono">{displayOrDash(row.stats_id)}</td>
+              <td className="px-2 py-1">{displayOrDash(row.kind)}</td>
+              <td className="px-2 py-1">{displayOrDash(row.packets_received)}</td>
+              <td className="px-2 py-1">{displayOrDash(row.packets_sent)}</td>
+              <td className="px-2 py-1">{displayOrDash(row.bytes_received)}</td>
+              <td className="px-2 py-1">{displayOrDash(row.bytes_sent)}</td>
+              <td className="px-2 py-1">{displayOrDash(row.round_trip_time)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/components/Sessions/SessionFilter.tsx
+++ b/src/components/Sessions/SessionFilter.tsx
@@ -1,0 +1,128 @@
+import type { FunctionComponent } from "preact";
+
+import type { SessionsSearchParams } from "@/sessionsSearchParams";
+
+export interface SessionFilterProps {
+  value: SessionsSearchParams;
+  onChange: (next: SessionsSearchParams) => void;
+}
+
+// 一覧絞り込みフォーム。適用時に親へ SessionsSearchParams を渡す
+export const SessionFilter: FunctionComponent<SessionFilterProps> = ({ value, onChange }) => {
+  const handleSubmit = (event: Event): void => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+    const data = new FormData(form);
+    const next: SessionsSearchParams = {};
+    const sessionId = data.get("sessionId");
+    if (typeof sessionId === "string" && sessionId !== "") {
+      next.sessionId = sessionId;
+    }
+    const connectionId = data.get("connectionId");
+    if (typeof connectionId === "string" && connectionId !== "") {
+      next.connectionId = connectionId;
+    }
+    const channelId = data.get("channelId");
+    if (typeof channelId === "string" && channelId !== "") {
+      next.channelId = channelId;
+    }
+    const from = data.get("from");
+    if (typeof from === "string" && from !== "") {
+      next.from = from;
+    }
+    const to = data.get("to");
+    if (typeof to === "string" && to !== "") {
+      next.to = to;
+    }
+    // 詳細選択はフィルタ変更で維持する
+    if (value.sessionDbId !== undefined) {
+      next.sessionDbId = value.sessionDbId;
+    }
+    onChange(next);
+  };
+
+  const handleClear = (): void => {
+    const next: SessionsSearchParams = {};
+    if (value.sessionDbId !== undefined) {
+      next.sessionDbId = value.sessionDbId;
+    }
+    onChange(next);
+  };
+
+  return (
+    <form
+      className="mb-4 grid grid-cols-1 gap-2 md:grid-cols-3 lg:grid-cols-6"
+      onSubmit={handleSubmit}
+      data-testid="session-filter"
+    >
+      <label className="flex flex-col text-sm">
+        <span className="mb-1 text-bs-secondary">channelId</span>
+        <input
+          name="channelId"
+          type="text"
+          className="rounded border border-bs-secondary px-2 py-1"
+          defaultValue={value.channelId ?? ""}
+          key={`channelId-${value.channelId ?? ""}`}
+        />
+      </label>
+      <label className="flex flex-col text-sm">
+        <span className="mb-1 text-bs-secondary">sessionId</span>
+        <input
+          name="sessionId"
+          type="text"
+          className="rounded border border-bs-secondary px-2 py-1"
+          defaultValue={value.sessionId ?? ""}
+          key={`sessionId-${value.sessionId ?? ""}`}
+        />
+      </label>
+      <label className="flex flex-col text-sm">
+        <span className="mb-1 text-bs-secondary">connectionId</span>
+        <input
+          name="connectionId"
+          type="text"
+          className="rounded border border-bs-secondary px-2 py-1"
+          defaultValue={value.connectionId ?? ""}
+          key={`connectionId-${value.connectionId ?? ""}`}
+        />
+      </label>
+      <label className="flex flex-col text-sm">
+        <span className="mb-1 text-bs-secondary">from (UTC)</span>
+        <input
+          name="from"
+          type="date"
+          className="rounded border border-bs-secondary px-2 py-1"
+          defaultValue={value.from ?? ""}
+          key={`from-${value.from ?? ""}`}
+        />
+      </label>
+      <label className="flex flex-col text-sm">
+        <span className="mb-1 text-bs-secondary">to (UTC)</span>
+        <input
+          name="to"
+          type="date"
+          className="rounded border border-bs-secondary px-2 py-1"
+          defaultValue={value.to ?? ""}
+          key={`to-${value.to ?? ""}`}
+        />
+      </label>
+      <div className="flex items-end gap-2">
+        <button
+          type="submit"
+          className="rounded border border-bs-primary bg-bs-primary px-3 py-1 text-sm text-white"
+        >
+          絞り込み
+        </button>
+        <button
+          type="button"
+          className="rounded border border-bs-secondary px-3 py-1 text-sm"
+          onClick={handleClear}
+        >
+          クリア
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/src/components/Sessions/SessionList.tsx
+++ b/src/components/Sessions/SessionList.tsx
@@ -1,0 +1,79 @@
+import type { FunctionComponent } from "preact";
+
+import type { SessionListRow } from "@/sessionDatabase";
+import { deriveSessionStatus, sessionStatusLabel } from "@/sessionStatus";
+
+export interface SessionListProps {
+  sessions: SessionListRow[];
+  currentSessionDbId: number | null;
+  selectedSessionDbId: number | undefined;
+  onSelect: (sessionDbId: number) => void;
+}
+
+function displayOrDash(value: string | null): string {
+  if (value === null || value === "") {
+    return "—";
+  }
+  return value;
+}
+
+// セッション一覧テーブル（session 行単位。connectionId は出さない）
+export const SessionList: FunctionComponent<SessionListProps> = ({
+  sessions,
+  currentSessionDbId,
+  selectedSessionDbId,
+  onSelect,
+}) => {
+  if (sessions.length === 0) {
+    return (
+      <p className="text-bs-secondary" data-testid="session-list-empty">
+        保存されたセッションはありません
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto" data-testid="session-list">
+      <table className="w-full border-collapse text-left text-sm">
+        <thead>
+          <tr className="border-b border-bs-secondary">
+            <th className="px-2 py-1">channelId</th>
+            <th className="px-2 py-1">session_id</th>
+            <th className="px-2 py-1">started_at</th>
+            <th className="px-2 py-1">ended_at</th>
+            <th className="px-2 py-1">状態</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sessions.map((session) => {
+            const status = deriveSessionStatus(session.ended_at, session.id, currentSessionDbId);
+            const selected = selectedSessionDbId === session.id;
+            let rowClass = "border-b border-bs-light cursor-pointer hover:bg-bs-light";
+            if (selected) {
+              rowClass = "border-b border-bs-light cursor-pointer bg-[#e7f1ff]";
+            }
+            return (
+              <tr
+                key={session.id}
+                className={rowClass}
+                data-testid={`session-row-${session.id}`}
+                data-session-db-id={String(session.id)}
+                onClick={() => {
+                  onSelect(session.id);
+                }}
+              >
+                <td className="px-2 py-1">{displayOrDash(session.channel_id)}</td>
+                <td className="px-2 py-1 font-mono text-xs">{displayOrDash(session.session_id)}</td>
+                <td className="px-2 py-1 font-mono text-xs">{displayOrDash(session.started_at)}</td>
+                <td className="px-2 py-1 font-mono text-xs">{displayOrDash(session.ended_at)}</td>
+                <td className="px-2 py-1" data-testid={`session-status-${session.id}`}>
+                  {sessionStatusLabel(status)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/components/Sessions/StatsChart.tsx
+++ b/src/components/Sessions/StatsChart.tsx
@@ -1,0 +1,89 @@
+import type { FunctionComponent } from "preact";
+
+import type { StatsTimeseriesPoint } from "@/statsQuery";
+
+export interface StatsChartProps {
+  points: StatsTimeseriesPoint[];
+  metric: "bitrate_send_bps" | "bitrate_recv_bps" | "round_trip_time";
+  title: string;
+}
+
+function metricValue(
+  point: StatsTimeseriesPoint,
+  metric: StatsChartProps["metric"],
+): number | null {
+  if (metric === "bitrate_send_bps") {
+    return point.bitrate_send_bps;
+  }
+  if (metric === "bitrate_recv_bps") {
+    return point.bitrate_recv_bps;
+  }
+  return point.round_trip_time;
+}
+
+// チャートライブラリ無しの簡易 SVG スパークライン
+export const StatsChart: FunctionComponent<StatsChartProps> = ({ points, metric, title }) => {
+  const width = 480;
+  const height = 120;
+  const padding = 8;
+
+  const values: number[] = [];
+  for (const point of points) {
+    const value = metricValue(point, metric);
+    if (value !== null) {
+      values.push(value);
+    }
+  }
+
+  if (values.length === 0) {
+    return (
+      <div className="mb-3" data-testid={`stats-chart-${metric}`}>
+        <h4 className="mb-1 text-sm font-semibold">{title}</h4>
+        <p className="text-sm text-bs-secondary">表示できる時系列データがありません</p>
+      </div>
+    );
+  }
+
+  let min = values[0] ?? 0;
+  let max = values[0] ?? 0;
+  for (const value of values) {
+    if (value < min) {
+      min = value;
+    }
+    if (value > max) {
+      max = value;
+    }
+  }
+  const range = max - min;
+  const effectiveRange = range === 0 ? 1 : range;
+
+  const pathParts: string[] = [];
+  for (const [index, point] of points.entries()) {
+    const value = metricValue(point, metric);
+    if (value === null) {
+      continue;
+    }
+    const x =
+      padding + (points.length === 1 ? 0 : (index / (points.length - 1)) * (width - padding * 2));
+    const y = height - padding - ((value - min) / effectiveRange) * (height - padding * 2);
+    if (pathParts.length === 0) {
+      pathParts.push(`M ${x} ${y}`);
+    } else {
+      pathParts.push(`L ${x} ${y}`);
+    }
+  }
+
+  return (
+    <div className="mb-3" data-testid={`stats-chart-${metric}`}>
+      <h4 className="mb-1 text-sm font-semibold">{title}</h4>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="w-full max-w-[480px] rounded border border-bs-light bg-white"
+        role="img"
+        aria-label={title}
+      >
+        <path d={pathParts.join(" ")} fill="none" stroke="#0d6efd" strokeWidth="2" />
+      </svg>
+    </div>
+  );
+};

--- a/src/routes/Sessions.tsx
+++ b/src/routes/Sessions.tsx
@@ -1,5 +1,181 @@
 import type { FunctionComponent } from "preact";
+import { useEffect, useState } from "preact/hooks";
+import { useLocation } from "preact-iso";
 
-const Sessions: FunctionComponent = () => <h1>Sessions</h1>;
+import { SessionDetail } from "@/components/Sessions/SessionDetail";
+import { SessionFilter } from "@/components/Sessions/SessionFilter";
+import { SessionList } from "@/components/Sessions/SessionList";
+import { getCurrentSessionDbId, listSessions, whenReady } from "@/sessionDatabase";
+import type { SessionListRow } from "@/sessionDatabase";
+import { buildSessionsPath, parseSessionsSearchParams } from "@/sessionsSearchParams";
+import type { SessionsSearchParams } from "@/sessionsSearchParams";
+
+// 不正な QS が落ちたときだけ URL を正規化する（パラメータ順の差では置換しない）
+function shouldNormalizeSearch(search: string, parsed: SessionsSearchParams): boolean {
+  const normalized = search.startsWith("?") ? search.slice(1) : search;
+  const raw = new URLSearchParams(normalized);
+
+  const rawSessionDbId = raw.get("sessionDbId");
+  if (rawSessionDbId !== null && rawSessionDbId !== "" && parsed.sessionDbId === undefined) {
+    return true;
+  }
+
+  const rawFrom = raw.get("from");
+  const rawTo = raw.get("to");
+  if (rawFrom !== null && rawFrom !== "" && parsed.from === undefined) {
+    return true;
+  }
+  if (rawTo !== null && rawTo !== "" && parsed.to === undefined) {
+    return true;
+  }
+
+  return false;
+}
+
+// プライバシー文言（端末内 OPFS・端末情報・複数タブ注意）
+function PrivacyNotice() {
+  return (
+    <aside
+      className="mb-4 rounded border border-bs-secondary bg-bs-light p-3 text-sm"
+      data-testid="sessions-privacy-notice"
+    >
+      <ul className="list-disc space-y-1 pl-5">
+        <li>データは端末内の OPFS に保存され、外部サーバーには送信されません</li>
+        <li>接続記録に端末情報（IP アドレス等）が含まれることがあります</li>
+        <li>複数タブで同時に開くとデータ破損のリスクがあります。1 つのタブだけを使ってください</li>
+      </ul>
+    </aside>
+  );
+}
+
+const Sessions: FunctionComponent = () => {
+  const { url, route } = useLocation();
+  const [searchParams, setSearchParams] = useState<SessionsSearchParams>(() =>
+    parseSessionsSearchParams(globalThis.location.search),
+  );
+  const [sessions, setSessions] = useState<SessionListRow[]>([]);
+  const [currentSessionDbId, setCurrentSessionDbId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // URL 変更に追従してフィルタ状態を同期し、不正値は正規化する
+  useEffect(() => {
+    const searchIndex = url.indexOf("?");
+    const { search: locationSearch } = globalThis.location;
+    let search = locationSearch;
+    if (searchIndex !== -1) {
+      search = url.slice(searchIndex);
+    }
+    const parsed = parseSessionsSearchParams(search);
+    setSearchParams(parsed);
+
+    if (shouldNormalizeSearch(search, parsed)) {
+      route(buildSessionsPath(parsed), true);
+    }
+  }, [url, route]);
+
+  // マウント時・フィルタ変更時に一覧を再取得する
+  useEffect(() => {
+    const active = { cancelled: false };
+    setLoading(true);
+    setErrorMessage(null);
+
+    void (async () => {
+      try {
+        await whenReady();
+        if (active.cancelled) {
+          return;
+        }
+        const filter = {
+          ...(searchParams.sessionId !== undefined ? { sessionId: searchParams.sessionId } : {}),
+          ...(searchParams.connectionId !== undefined
+            ? { connectionId: searchParams.connectionId }
+            : {}),
+          ...(searchParams.channelId !== undefined ? { channelId: searchParams.channelId } : {}),
+          ...(searchParams.from !== undefined ? { from: searchParams.from } : {}),
+          ...(searchParams.to !== undefined ? { to: searchParams.to } : {}),
+        };
+        const rows = await listSessions(filter);
+        // await 中に cleanup で cancelled が立つ可能性がある
+        // oxlint-disable-next-line typescript/no-unnecessary-condition
+        if (active.cancelled) {
+          return;
+        }
+        setSessions(rows);
+        setCurrentSessionDbId(getCurrentSessionDbId());
+        setLoading(false);
+      } catch (error) {
+        if (active.cancelled) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : "Failed to load session list";
+        console.warn(`Session list load failed: ${message}`);
+        setErrorMessage(message);
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      active.cancelled = true;
+    };
+  }, [
+    searchParams.sessionId,
+    searchParams.connectionId,
+    searchParams.channelId,
+    searchParams.from,
+    searchParams.to,
+  ]);
+
+  const applySearchParams = (next: SessionsSearchParams): void => {
+    const path = buildSessionsPath(next);
+    route(path, true);
+  };
+
+  const handleSelect = (sessionDbId: number): void => {
+    applySearchParams({ ...searchParams, sessionDbId });
+  };
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-4" data-testid="sessions-page">
+      <h1 className="mb-3 text-2xl font-semibold">Sessions</h1>
+      <PrivacyNotice />
+
+      {errorMessage !== null ? (
+        <div
+          className="mb-4 rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800"
+          data-testid="sessions-page-error"
+          role="alert"
+        >
+          セッション一覧の読み取りに失敗しました: {errorMessage}
+        </div>
+      ) : null}
+
+      <SessionFilter value={searchParams} onChange={applySearchParams} />
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-lg font-semibold">一覧</h2>
+        {loading ? (
+          <p className="text-bs-secondary" data-testid="session-list-loading">
+            読み込み中…
+          </p>
+        ) : (
+          <SessionList
+            sessions={sessions}
+            currentSessionDbId={currentSessionDbId}
+            selectedSessionDbId={searchParams.sessionDbId}
+            onSelect={handleSelect}
+          />
+        )}
+      </section>
+
+      <section>
+        <SessionDetail
+          key={searchParams.sessionDbId === undefined ? "none" : String(searchParams.sessionDbId)}
+          sessionDbId={searchParams.sessionDbId}
+        />
+      </section>
+    </main>
+  );
+};
 
 export default Sessions;

--- a/src/sessionDatabase.ts
+++ b/src/sessionDatabase.ts
@@ -4,9 +4,75 @@
 import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 
 import { setSoraErrorAlertMessage } from "@/app/signals";
+import { computeStatsAggregates, computeStatsTimeseries } from "@/statsQuery";
+import type { StatsAggregates, StatsSourceRow, StatsTimeseriesPoint } from "@/statsQuery";
 import type { Json } from "@/types";
 import { selectIdsToDeleteForSampling } from "@/webrtcStatsNormalizer";
 import type { NormalizedWebrtcStat } from "@/webrtcStatsNormalizer";
+
+// 読み取り API の戻り型（時刻は ISO 相当の文字列）
+export interface SessionListRow {
+  id: number;
+  session_id: string | null;
+  channel_id: string | null;
+  role: string | null;
+  started_at: string | null;
+  ended_at: string | null;
+}
+
+export interface ConnectionListRow {
+  id: number;
+  session_db_id: number;
+  session_id: string | null;
+  connection_id: string | null;
+  sora_client_id: string | null;
+  channel_id: string | null;
+  signaling_url: string | null;
+  started_at: string | null;
+  ended_at: string | null;
+}
+
+export interface SessionDetail {
+  session: SessionListRow;
+  connections: ConnectionListRow[];
+}
+
+export interface SessionListFilter {
+  sessionId?: string;
+  connectionId?: string;
+  channelId?: string;
+  from?: string;
+  to?: string;
+}
+
+export interface StatsPageRow {
+  id: number;
+  timestamp_ms: number;
+  stats_type: string | null;
+  stats_id: string | null;
+  kind: string | null;
+  packets_received: number | null;
+  packets_sent: number | null;
+  bytes_received: number | null;
+  bytes_sent: number | null;
+  round_trip_time: number | null;
+}
+
+export interface StatsPageResult {
+  rows: StatsPageRow[];
+  totalCount: number;
+}
+
+export interface StatsTimeseriesOptions {
+  intervalSec?: number;
+}
+
+export interface StatsPageOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export type { StatsAggregates, StatsTimeseriesPoint } from "@/statsQuery";
 
 // OPFS 上の DuckDB データベースパス（signaling-url-candidates.json と衝突しない名前）
 const OPFS_DB_PATH = "opfs://sora-devtools-sessions.db";
@@ -1048,4 +1114,360 @@ export async function querySessionDatabaseForE2e(
 // E2E ヘルパーから OPFS 上の DB ファイルを削除するために export する
 export async function deleteSessionDatabaseFiles(): Promise<void> {
   await deleteOpfsDatabaseFile();
+}
+
+// --- 読み取り API（書き込みと同じ直列化キュー経由） ---
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "bigint") {
+    const asNumber = Number(value);
+    if (!Number.isFinite(asNumber)) {
+      return null;
+    }
+    return asNumber;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return null;
+}
+
+function toNullableString(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  // DuckDB TIMESTAMP が Date で返る場合
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return null;
+}
+
+function requireNumber(value: unknown, label: string): number {
+  const numberValue = toFiniteNumber(value);
+  if (numberValue === null) {
+    throw new Error(`${label} is not a finite number: ${JSON.stringify(value)}`);
+  }
+  return numberValue;
+}
+
+function arrowTableToRecords(table: { toArray: () => unknown[] }): Array<Record<string, unknown>> {
+  return table.toArray().map((row) => {
+    if (typeof row !== "object" || row === null) {
+      return {};
+    }
+    if ("toJSON" in row && typeof (row as { toJSON?: unknown }).toJSON === "function") {
+      const json: unknown = (row as { toJSON: () => unknown }).toJSON();
+      if (typeof json === "object" && json !== null) {
+        return json as Record<string, unknown>;
+      }
+    }
+    return row as Record<string, unknown>;
+  });
+}
+
+function mapSessionListRow(record: Record<string, unknown>): SessionListRow {
+  return {
+    id: requireNumber(record.id, "sessions.id"),
+    session_id: toNullableString(record.session_id),
+    channel_id: toNullableString(record.channel_id),
+    role: toNullableString(record.role),
+    started_at: toNullableString(record.started_at),
+    ended_at: toNullableString(record.ended_at),
+  };
+}
+
+function mapConnectionListRow(record: Record<string, unknown>): ConnectionListRow {
+  return {
+    id: requireNumber(record.id, "connections.id"),
+    session_db_id: requireNumber(record.session_db_id, "connections.session_db_id"),
+    session_id: toNullableString(record.session_id),
+    connection_id: toNullableString(record.connection_id),
+    sora_client_id: toNullableString(record.sora_client_id),
+    channel_id: toNullableString(record.channel_id),
+    signaling_url: toNullableString(record.signaling_url),
+    started_at: toNullableString(record.started_at),
+    ended_at: toNullableString(record.ended_at),
+  };
+}
+
+// YYYY-MM-DD を UTC 当日 00:00:00 の TIMESTAMP 文字列にする
+function dateOnlyToUtcTimestamp(dateOnly: string): string {
+  return `${dateOnly} 00:00:00`;
+}
+
+// YYYY-MM-DD の翌日 00:00:00 UTC（to の exclusive end）
+function dateOnlyToExclusiveEndTimestamp(dateOnly: string): string {
+  const match = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/u.exec(dateOnly);
+  if (match?.groups === undefined) {
+    throw new Error(`Invalid date-only value: ${dateOnly}`);
+  }
+  const year = Number(match.groups.year);
+  const month = Number(match.groups.month);
+  const day = Number(match.groups.day);
+  const next = new Date(Date.UTC(year, month - 1, day + 1));
+  const yyyy = String(next.getUTCFullYear()).padStart(4, "0");
+  const mm = String(next.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(next.getUTCDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd} 00:00:00`;
+}
+
+const SESSION_LIST_SELECT = `
+  SELECT
+    id,
+    session_id,
+    channel_id,
+    role,
+    CAST(started_at AS VARCHAR) AS started_at,
+    CAST(ended_at AS VARCHAR) AS ended_at
+  FROM sessions
+`;
+
+// 一覧（session 行単位）。未初期化時は空配列
+export async function listSessions(filter: SessionListFilter = {}): Promise<SessionListRow[]> {
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return [];
+    }
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    if (filter.sessionId !== undefined) {
+      conditions.push("session_id = ?");
+      params.push(filter.sessionId);
+    }
+    if (filter.channelId !== undefined) {
+      conditions.push("channel_id = ?");
+      params.push(filter.channelId);
+    }
+    if (filter.from !== undefined) {
+      conditions.push("started_at >= CAST(? AS TIMESTAMP)");
+      params.push(dateOnlyToUtcTimestamp(filter.from));
+    }
+    if (filter.to !== undefined) {
+      conditions.push("started_at < CAST(? AS TIMESTAMP)");
+      params.push(dateOnlyToExclusiveEndTimestamp(filter.to));
+    }
+    if (filter.connectionId !== undefined) {
+      conditions.push(`EXISTS (
+        SELECT 1 FROM connections c
+        WHERE c.session_db_id = sessions.id AND c.connection_id = ?
+      )`);
+      params.push(filter.connectionId);
+    }
+    let sql = SESSION_LIST_SELECT;
+    if (conditions.length > 0) {
+      sql += ` WHERE ${conditions.join(" AND ")}`;
+    }
+    sql += " ORDER BY started_at DESC NULLS LAST, id DESC";
+    const statement = await duckdbConnection.prepare(sql);
+    try {
+      const table = await statement.query(...params);
+      return arrowTableToRecords(table).map((record) => mapSessionListRow(record));
+    } finally {
+      await statement.close();
+    }
+  });
+}
+
+// 詳細（session + connections）。無ければ null。未初期化時も null
+export async function getSession(sessionDbId: number): Promise<SessionDetail | null> {
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return null;
+    }
+    const sessionStatement = await duckdbConnection.prepare(`
+      ${SESSION_LIST_SELECT}
+      WHERE id = ?
+    `);
+    let sessionRow: SessionListRow | null = null;
+    try {
+      const sessionTable = await sessionStatement.query(sessionDbId);
+      const sessionRecords = arrowTableToRecords(sessionTable);
+      if (sessionRecords.length === 0) {
+        return null;
+      }
+      const [first] = sessionRecords;
+      sessionRow = mapSessionListRow(first);
+    } finally {
+      await sessionStatement.close();
+    }
+
+    const connectionStatement = await duckdbConnection.prepare(`
+      SELECT
+        id,
+        session_db_id,
+        session_id,
+        connection_id,
+        sora_client_id,
+        channel_id,
+        signaling_url,
+        CAST(started_at AS VARCHAR) AS started_at,
+        CAST(ended_at AS VARCHAR) AS ended_at
+      FROM connections
+      WHERE session_db_id = ?
+      ORDER BY started_at ASC NULLS LAST, id ASC
+    `);
+    try {
+      const connectionTable = await connectionStatement.query(sessionDbId);
+      const connections = arrowTableToRecords(connectionTable).map((record) =>
+        mapConnectionListRow(record),
+      );
+      return { session: sessionRow, connections };
+    } finally {
+      await connectionStatement.close();
+    }
+  });
+}
+
+async function loadStatsSourceRowsUnlocked(sessionDbId: number): Promise<StatsSourceRow[]> {
+  if (duckdbConnection === null) {
+    return [];
+  }
+  const statement = await duckdbConnection.prepare(`
+    SELECT
+      id,
+      timestamp_ms,
+      stats_type,
+      stats_id,
+      packets_received,
+      packets_lost,
+      packets_sent,
+      bytes_received,
+      bytes_sent,
+      round_trip_time
+    FROM webrtc_stats
+    WHERE session_db_id = ?
+    ORDER BY timestamp_ms ASC, id ASC
+  `);
+  try {
+    const table = await statement.query(sessionDbId);
+    return arrowTableToRecords(table).map((record) => {
+      const statsType = toNullableString(record.stats_type);
+      const statsId = toNullableString(record.stats_id);
+      return {
+        id: requireNumber(record.id, "webrtc_stats.id"),
+        timestamp_ms: requireNumber(record.timestamp_ms, "webrtc_stats.timestamp_ms"),
+        stats_type: statsType ?? "",
+        stats_id: statsId ?? "",
+        packets_received: toFiniteNumber(record.packets_received),
+        packets_lost: toFiniteNumber(record.packets_lost),
+        packets_sent: toFiniteNumber(record.packets_sent),
+        bytes_received: toFiniteNumber(record.bytes_received),
+        bytes_sent: toFiniteNumber(record.bytes_sent),
+        round_trip_time: toFiniteNumber(record.round_trip_time),
+      };
+    });
+  } finally {
+    await statement.close();
+  }
+}
+
+// 集計値。未初期化時は全フィールド null
+export async function queryStatsAggregates(sessionDbId: number): Promise<StatsAggregates> {
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return computeStatsAggregates([]);
+    }
+    const rows = await loadStatsSourceRowsUnlocked(sessionDbId);
+    return computeStatsAggregates(rows);
+  });
+}
+
+// 時系列サンプリング。intervalSec は 10 または 60（省略時 10）
+export async function queryStatsTimeseries(
+  sessionDbId: number,
+  options: StatsTimeseriesOptions = {},
+): Promise<StatsTimeseriesPoint[]> {
+  const intervalSec = options.intervalSec ?? 10;
+  if (intervalSec !== 10 && intervalSec !== 60) {
+    throw new Error(`intervalSec must be 10 or 60, got ${String(intervalSec)}`);
+  }
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return [];
+    }
+    const rows = await loadStatsSourceRowsUnlocked(sessionDbId);
+    return computeStatsTimeseries(rows, intervalSec);
+  });
+}
+
+// ページネーション付き生データ
+export async function queryStatsPage(
+  sessionDbId: number,
+  options: StatsPageOptions = {},
+): Promise<StatsPageResult> {
+  const limit = options.limit ?? 50;
+  const offset = options.offset ?? 0;
+  if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+    throw new Error(`limit must be an integer in 1..200, got ${String(limit)}`);
+  }
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error(`offset must be a non-negative integer, got ${String(offset)}`);
+  }
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return { rows: [], totalCount: 0 };
+    }
+    const countStatement = await duckdbConnection.prepare(`
+      SELECT COUNT(*) AS total_count
+      FROM webrtc_stats
+      WHERE session_db_id = ?
+    `);
+    let totalCount = 0;
+    try {
+      const countTable = await countStatement.query(sessionDbId);
+      const countRecords = arrowTableToRecords(countTable);
+      if (countRecords.length > 0) {
+        const [first] = countRecords;
+        totalCount = requireNumber(first.total_count, "webrtc_stats total_count");
+      }
+    } finally {
+      await countStatement.close();
+    }
+
+    const pageStatement = await duckdbConnection.prepare(`
+      SELECT
+        id,
+        timestamp_ms,
+        stats_type,
+        stats_id,
+        kind,
+        packets_received,
+        packets_sent,
+        bytes_received,
+        bytes_sent,
+        round_trip_time
+      FROM webrtc_stats
+      WHERE session_db_id = ?
+      ORDER BY timestamp_ms ASC, id ASC
+      LIMIT ?
+      OFFSET ?
+    `);
+    try {
+      const pageTable = await pageStatement.query(sessionDbId, limit, offset);
+      const rows = arrowTableToRecords(pageTable).map(
+        (record): StatsPageRow => ({
+          id: requireNumber(record.id, "webrtc_stats.id"),
+          timestamp_ms: requireNumber(record.timestamp_ms, "webrtc_stats.timestamp_ms"),
+          stats_type: toNullableString(record.stats_type),
+          stats_id: toNullableString(record.stats_id),
+          kind: toNullableString(record.kind),
+          packets_received: toFiniteNumber(record.packets_received),
+          packets_sent: toFiniteNumber(record.packets_sent),
+          bytes_received: toFiniteNumber(record.bytes_received),
+          bytes_sent: toFiniteNumber(record.bytes_sent),
+          round_trip_time: toFiniteNumber(record.round_trip_time),
+        }),
+      );
+      return { rows, totalCount };
+    } finally {
+      await pageStatement.close();
+    }
+  });
 }

--- a/src/sessionStatus.test.ts
+++ b/src/sessionStatus.test.ts
@@ -1,0 +1,27 @@
+import { assert, test } from "vite-plus/test";
+
+import { deriveSessionStatus, sessionStatusLabel } from "./sessionStatus.ts";
+
+// ended_at があれば常に切断済み
+test("deriveSessionStatus は ended_at があるとき切断済みを返す", () => {
+  assert.equal(deriveSessionStatus("2026-07-11 12:00:00", 1, 1), "ended");
+  assert.equal(deriveSessionStatus("2026-07-11 12:00:00", 1, null), "ended");
+});
+
+// ended_at がなく current と一致すれば接続中
+test("deriveSessionStatus は ended_at がなく current と一致するとき接続中を返す", () => {
+  assert.equal(deriveSessionStatus(null, 42, 42), "connected");
+});
+
+// ended_at がなく current 不一致・null なら切断不確定
+test("deriveSessionStatus は ended_at がなく current 不一致のとき切断不確定を返す", () => {
+  assert.equal(deriveSessionStatus(null, 1, 2), "uncertain");
+  assert.equal(deriveSessionStatus(null, 1, null), "uncertain");
+});
+
+// ラベルは 3 状態を日本語で返す
+test("sessionStatusLabel は 3 状態の日本語ラベルを返す", () => {
+  assert.equal(sessionStatusLabel("ended"), "切断済み");
+  assert.equal(sessionStatusLabel("connected"), "接続中");
+  assert.equal(sessionStatusLabel("uncertain"), "切断不確定");
+});

--- a/src/sessionStatus.ts
+++ b/src/sessionStatus.ts
@@ -1,0 +1,30 @@
+// セッション一覧・詳細で使う 3 状態の判定
+
+export type SessionStatus = "ended" | "connected" | "uncertain";
+
+// ended_at と現在の接続試行 ID から表示用の状態を導出する
+// 切断済み: ended_at あり / 接続中: ended_at なしかつ current と一致 / それ以外は切断不確定
+export function deriveSessionStatus(
+  endedAt: string | null,
+  sessionDbId: number,
+  currentSessionDbId: number | null,
+): SessionStatus {
+  if (endedAt !== null) {
+    return "ended";
+  }
+  if (currentSessionDbId !== null && currentSessionDbId === sessionDbId) {
+    return "connected";
+  }
+  return "uncertain";
+}
+
+// UI 表示用の日本語ラベル
+export function sessionStatusLabel(status: SessionStatus): string {
+  if (status === "ended") {
+    return "切断済み";
+  }
+  if (status === "connected") {
+    return "接続中";
+  }
+  return "切断不確定";
+}

--- a/src/sessionsSearchParams.test.ts
+++ b/src/sessionsSearchParams.test.ts
@@ -1,0 +1,89 @@
+import { assert, test } from "vite-plus/test";
+
+import {
+  buildSessionsPath,
+  buildSessionsSearchParams,
+  isValidDateOnly,
+  parseSessionDbId,
+  parseSessionsSearchParams,
+} from "./sessionsSearchParams.ts";
+
+// YYYY-MM-DD の妥当性
+test("isValidDateOnly は正しい日付のみ true を返す", () => {
+  assert.isTrue(isValidDateOnly("2026-07-11"));
+  assert.isTrue(isValidDateOnly("2024-02-29"));
+  assert.isFalse(isValidDateOnly("2026-7-11"));
+  assert.isFalse(isValidDateOnly("2026-13-01"));
+  assert.isFalse(isValidDateOnly("2026-02-30"));
+  assert.isFalse(isValidDateOnly("not-a-date"));
+});
+
+// sessionDbId は正の整数のみ
+test("parseSessionDbId は正の整数のみ受け付ける", () => {
+  assert.equal(parseSessionDbId("1"), 1);
+  assert.equal(parseSessionDbId("42"), 42);
+  assert.equal(parseSessionDbId(null), undefined);
+  assert.equal(parseSessionDbId(""), undefined);
+  assert.equal(parseSessionDbId("0"), undefined);
+  assert.equal(parseSessionDbId("-1"), undefined);
+  assert.equal(parseSessionDbId("1.5"), undefined);
+  assert.equal(parseSessionDbId("abc"), undefined);
+});
+
+// 正常な QS を読む
+test("parseSessionsSearchParams は有効なフィルタを読む", () => {
+  const parsed = parseSessionsSearchParams(
+    "?sessionId=s1&connectionId=c1&channelId=ch&from=2026-07-01&to=2026-07-11&sessionDbId=3",
+  );
+  assert.deepEqual(parsed, {
+    sessionId: "s1",
+    connectionId: "c1",
+    channelId: "ch",
+    from: "2026-07-01",
+    to: "2026-07-11",
+    sessionDbId: 3,
+  });
+});
+
+// 不正な from/to/sessionDbId は落とす
+test("parseSessionsSearchParams は不正な日付と sessionDbId を未指定にする", () => {
+  const parsed = parseSessionsSearchParams("from=2026-13-01&to=bad&sessionDbId=nope&channelId=ok");
+  assert.deepEqual(parsed, { channelId: "ok" });
+});
+
+// from > to なら両方落とす
+test("parseSessionsSearchParams は from が to より後なら日付を落とす", () => {
+  const parsed = parseSessionsSearchParams("from=2026-07-20&to=2026-07-10&channelId=ch");
+  assert.deepEqual(parsed, { channelId: "ch" });
+});
+
+// 組み立てとラウンドトリップ
+test("buildSessionsSearchParams は空値を載せない", () => {
+  const search = buildSessionsSearchParams({
+    channelId: "ch",
+    sessionDbId: 9,
+  });
+  assert.equal(search.get("channelId"), "ch");
+  assert.equal(search.get("sessionDbId"), "9");
+  assert.isNull(search.get("sessionId"));
+  assert.isNull(search.get("from"));
+});
+
+test("buildSessionsPath はクエリ無しなら /sessions のみ返す", () => {
+  assert.equal(buildSessionsPath({}), "/sessions");
+  assert.equal(buildSessionsPath({ channelId: "a" }), "/sessions?channelId=a");
+});
+
+test("parse と build はラウンドトリップできる", () => {
+  const original = {
+    sessionId: "s",
+    connectionId: "c",
+    channelId: "ch",
+    from: "2026-01-01",
+    to: "2026-01-31",
+    sessionDbId: 7,
+  };
+  const built = buildSessionsSearchParams(original);
+  const parsed = parseSessionsSearchParams(built);
+  assert.deepEqual(parsed, original);
+});

--- a/src/sessionsSearchParams.ts
+++ b/src/sessionsSearchParams.ts
@@ -1,0 +1,157 @@
+// /sessions ページ専用のクエリストリング読み書き
+// DevTools の signals には書き込まない
+
+export interface SessionsSearchParams {
+  sessionId?: string;
+  connectionId?: string;
+  channelId?: string;
+  from?: string;
+  to?: string;
+  sessionDbId?: number;
+}
+
+const DATE_ONLY_PATTERN = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/u;
+
+// YYYY-MM-DD として厳密に解釈できるか（月日の妥当性も確認する）
+export function isValidDateOnly(value: string): boolean {
+  const match = DATE_ONLY_PATTERN.exec(value);
+  if (match?.groups === undefined) {
+    return false;
+  }
+  const year = Number(match.groups.year);
+  const month = Number(match.groups.month);
+  const day = Number(match.groups.day);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return false;
+  }
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    return false;
+  }
+  // UTC で Date を組み立て、丸められていないか確認する
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  );
+}
+
+// from が to より後なら不正
+function isFromAfterTo(from: string, to: string): boolean {
+  return from > to;
+}
+
+// 正の整数（sessionDbId）として解釈できるか
+export function parseSessionDbId(raw: string | null): number | undefined {
+  if (raw === null || raw === "") {
+    return undefined;
+  }
+  if (!/^\d+$/u.test(raw)) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1) {
+    return undefined;
+  }
+  return value;
+}
+
+// location.search または URLSearchParams から Sessions 用パラメータを読む
+// 不正な from/to/sessionDbId は未指定扱い（呼び出し側で QS 正規化してよい）
+export function parseSessionsSearchParams(search: string | URLSearchParams): SessionsSearchParams {
+  let params: URLSearchParams;
+  if (typeof search === "string") {
+    const normalized = search.startsWith("?") ? search.slice(1) : search;
+    params = new URLSearchParams(normalized);
+  } else {
+    params = search;
+  }
+
+  const result: SessionsSearchParams = {};
+
+  const sessionId = params.get("sessionId");
+  if (sessionId !== null && sessionId !== "") {
+    result.sessionId = sessionId;
+  }
+
+  const connectionId = params.get("connectionId");
+  if (connectionId !== null && connectionId !== "") {
+    result.connectionId = connectionId;
+  }
+
+  const channelId = params.get("channelId");
+  if (channelId !== null && channelId !== "") {
+    result.channelId = channelId;
+  }
+
+  const from = params.get("from");
+  const to = params.get("to");
+  let validFrom: string | undefined;
+  let validTo: string | undefined;
+  if (from !== null && isValidDateOnly(from)) {
+    validFrom = from;
+  }
+  if (to !== null && isValidDateOnly(to)) {
+    validTo = to;
+  }
+  if (validFrom !== undefined && validTo !== undefined && isFromAfterTo(validFrom, validTo)) {
+    validFrom = undefined;
+    validTo = undefined;
+  }
+  if (validFrom !== undefined) {
+    result.from = validFrom;
+  }
+  if (validTo !== undefined) {
+    result.to = validTo;
+  }
+
+  const sessionDbId = parseSessionDbId(params.get("sessionDbId"));
+  if (sessionDbId !== undefined) {
+    result.sessionDbId = sessionDbId;
+  }
+
+  return result;
+}
+
+// Sessions 用パラメータから URLSearchParams を組み立てる（空値は載せない）
+export function buildSessionsSearchParams(params: SessionsSearchParams): URLSearchParams {
+  const search = new URLSearchParams();
+  if (params.sessionId !== undefined && params.sessionId !== "") {
+    search.set("sessionId", params.sessionId);
+  }
+  if (params.connectionId !== undefined && params.connectionId !== "") {
+    search.set("connectionId", params.connectionId);
+  }
+  if (params.channelId !== undefined && params.channelId !== "") {
+    search.set("channelId", params.channelId);
+  }
+  if (params.from !== undefined && isValidDateOnly(params.from)) {
+    search.set("from", params.from);
+  }
+  if (params.to !== undefined && isValidDateOnly(params.to)) {
+    search.set("to", params.to);
+  }
+  // from > to なら両方載せない
+  const fromValue = search.get("from");
+  const toValue = search.get("to");
+  if (fromValue !== null && toValue !== null && isFromAfterTo(fromValue, toValue)) {
+    search.delete("from");
+    search.delete("to");
+  }
+  if (
+    params.sessionDbId !== undefined &&
+    Number.isSafeInteger(params.sessionDbId) &&
+    params.sessionDbId >= 1
+  ) {
+    search.set("sessionDbId", String(params.sessionDbId));
+  }
+  return search;
+}
+
+// /sessions への path + search 文字列を組み立てる
+export function buildSessionsPath(params: SessionsSearchParams): string {
+  const search = buildSessionsSearchParams(params);
+  const query = search.toString();
+  if (query === "") {
+    return "/sessions";
+  }
+  return `/sessions?${query}`;
+}

--- a/src/statsQuery.test.ts
+++ b/src/statsQuery.test.ts
@@ -1,0 +1,242 @@
+import { assert, test } from "vite-plus/test";
+
+import { computeStatsAggregates, computeStatsTimeseries } from "./statsQuery.ts";
+import type { StatsSourceRow } from "./statsQuery.ts";
+
+function row(
+  partial: Partial<StatsSourceRow> &
+    Pick<StatsSourceRow, "id" | "timestamp_ms" | "stats_type" | "stats_id">,
+): StatsSourceRow {
+  return {
+    packets_received: null,
+    packets_lost: null,
+    packets_sent: null,
+    bytes_received: null,
+    bytes_sent: null,
+    round_trip_time: null,
+    ...partial,
+  };
+}
+
+// 空入力はすべて null
+test("computeStatsAggregates は空配列で全フィールド null を返す", () => {
+  assert.deepEqual(computeStatsAggregates([]), {
+    packets_received: null,
+    packets_sent: null,
+    packet_loss_rate: null,
+    rtt_min: null,
+    rtt_max: null,
+    rtt_avg: null,
+    bitrate_send_bps: null,
+    bitrate_recv_bps: null,
+  });
+});
+
+// stats_id 単位の最新行を合算する
+test("computeStatsAggregates は inbound/outbound の最新行を合算する", () => {
+  const rows: StatsSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 1000,
+      stats_type: "inbound-rtp",
+      stats_id: "in-a",
+      packets_received: 10,
+      packets_lost: 1,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 2000,
+      stats_type: "inbound-rtp",
+      stats_id: "in-a",
+      packets_received: 20,
+      packets_lost: 2,
+    }),
+    row({
+      id: 3,
+      timestamp_ms: 2000,
+      stats_type: "inbound-rtp",
+      stats_id: "in-b",
+      packets_received: 5,
+      packets_lost: 0,
+    }),
+    row({
+      id: 4,
+      timestamp_ms: 1000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      packets_sent: 3,
+    }),
+    row({
+      id: 5,
+      timestamp_ms: 3000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      packets_sent: 8,
+    }),
+  ];
+  const aggregates = computeStatsAggregates(rows);
+  assert.equal(aggregates.packets_received, 25);
+  assert.equal(aggregates.packets_sent, 8);
+  assert.equal(aggregates.packet_loss_rate, 2 / 27);
+});
+
+// RTT は candidate-pair 最新行の min/max/avg
+test("computeStatsAggregates は RTT の min/max/avg を返す", () => {
+  const rows: StatsSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 1000,
+      stats_type: "candidate-pair",
+      stats_id: "cp-a",
+      round_trip_time: 0.04,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 2000,
+      stats_type: "candidate-pair",
+      stats_id: "cp-a",
+      round_trip_time: 0.02,
+    }),
+    row({
+      id: 3,
+      timestamp_ms: 2000,
+      stats_type: "candidate-pair",
+      stats_id: "cp-b",
+      round_trip_time: 0.06,
+    }),
+  ];
+  const aggregates = computeStatsAggregates(rows);
+  assert.equal(aggregates.rtt_min, 0.02);
+  assert.equal(aggregates.rtt_max, 0.06);
+  assert.equal(aggregates.rtt_avg, 0.04);
+});
+
+// 正の bytes 差分だけ平均ビットレートにする
+test("computeStatsAggregates は正の bytes 差分だけ平均ビットレートにする", () => {
+  const rows: StatsSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 0,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 1000,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 1000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 2000,
+    }),
+  ];
+  const aggregates = computeStatsAggregates(rows);
+  // 1000 bytes / 1s * 8 = 8000 bps
+  assert.equal(aggregates.bitrate_send_bps, 8000);
+});
+
+// 時系列: バケット代表時刻と合算
+test("computeStatsTimeseries は intervalSec でバケット化する", () => {
+  const rows: StatsSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 0,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 0,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 1000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 1000,
+    }),
+    row({
+      id: 3,
+      timestamp_ms: 11_000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 2000,
+    }),
+  ];
+  const points = computeStatsTimeseries(rows, 10);
+  assert.isAtLeast(points.length, 1);
+  assert.equal(points[0]?.timestamp_ms, 0);
+  // 2 つ目のバケット（10000ms 台）
+  const second = points.find((point) => point.timestamp_ms === 10_000);
+  assert.isDefined(second);
+});
+
+// 同一バケット内の複数サンプルは stats_id 単位 last のみ使い、全サンプル合算しない
+test("computeStatsTimeseries はバケット内で stats_id 単位の last を使う", () => {
+  const rows: StatsSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 0,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 0,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 1000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 1000,
+    }),
+    row({
+      id: 3,
+      timestamp_ms: 2000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 3000,
+    }),
+  ];
+  const points = computeStatsTimeseries(rows, 10);
+  assert.equal(points.length, 1);
+  // last は id=3（2000ms）の差分: (3000-1000)*8*1000/1000 = 16000
+  // 全サンプル合算だと 8000+16000=24000 になる
+  assert.equal(points[0]?.bitrate_send_bps, 16_000);
+});
+
+// 同一バケットの複数 stats_id は last 同士を合算する
+test("computeStatsTimeseries は複数 stats_id の last を合算する", () => {
+  const rows: StatsSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 0,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 0,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 1000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 1000,
+    }),
+    row({
+      id: 3,
+      timestamp_ms: 0,
+      stats_type: "outbound-rtp",
+      stats_id: "out-b",
+      bytes_sent: 0,
+    }),
+    row({
+      id: 4,
+      timestamp_ms: 1000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-b",
+      bytes_sent: 500,
+    }),
+  ];
+  const points = computeStatsTimeseries(rows, 10);
+  assert.equal(points.length, 1);
+  // out-a: 8000 bps, out-b: 4000 bps → 合算 12000
+  assert.equal(points[0]?.bitrate_send_bps, 12_000);
+});
+
+test("computeStatsTimeseries は空配列で空を返す", () => {
+  assert.deepEqual(computeStatsTimeseries([], 10), []);
+});

--- a/src/statsQuery.ts
+++ b/src/statsQuery.ts
@@ -1,0 +1,355 @@
+// webrtc_stats の集計・時系列を純粋関数で計算する
+// ストリーム識別は stats_id のみ（第 1 段階）
+
+export interface StatsSourceRow {
+  id: number;
+  timestamp_ms: number;
+  stats_type: string;
+  stats_id: string;
+  packets_received: number | null;
+  packets_lost: number | null;
+  packets_sent: number | null;
+  bytes_received: number | null;
+  bytes_sent: number | null;
+  round_trip_time: number | null;
+}
+
+export interface StatsAggregates {
+  packets_received: number | null;
+  packets_sent: number | null;
+  packet_loss_rate: number | null;
+  rtt_min: number | null;
+  rtt_max: number | null;
+  rtt_avg: number | null;
+  bitrate_send_bps: number | null;
+  bitrate_recv_bps: number | null;
+}
+
+export interface StatsTimeseriesPoint {
+  timestamp_ms: number;
+  bitrate_send_bps: number | null;
+  bitrate_recv_bps: number | null;
+  round_trip_time: number | null;
+}
+
+// timestamp_ms 昇順・同値なら id 昇順で比較する
+function compareByTimeThenId(
+  a: { timestamp_ms: number; id: number },
+  b: { timestamp_ms: number; id: number },
+): number {
+  if (a.timestamp_ms !== b.timestamp_ms) {
+    return a.timestamp_ms - b.timestamp_ms;
+  }
+  return a.id - b.id;
+}
+
+// stats_id 単位の最新行を取る（timestamp_ms 最大、同値なら id 最大）
+function latestRowPerStatsId(rows: StatsSourceRow[]): Map<string, StatsSourceRow> {
+  const latest = new Map<string, StatsSourceRow>();
+  for (const row of rows) {
+    const existing = latest.get(row.stats_id);
+    if (existing === undefined) {
+      latest.set(row.stats_id, row);
+      continue;
+    }
+    if (compareByTimeThenId(existing, row) < 0) {
+      latest.set(row.stats_id, row);
+    }
+  }
+  return latest;
+}
+
+function sumNullable(values: Array<number | null>): number | null {
+  let total = 0;
+  let hasValue = false;
+  for (const value of values) {
+    if (value === null) {
+      continue;
+    }
+    total += value;
+    hasValue = true;
+  }
+  if (!hasValue) {
+    return null;
+  }
+  return total;
+}
+
+function averageNullable(values: Array<number | null>): number | null {
+  let total = 0;
+  let count = 0;
+  for (const value of values) {
+    if (value === null) {
+      continue;
+    }
+    total += value;
+    count += 1;
+  }
+  if (count === 0) {
+    return null;
+  }
+  return total / count;
+}
+
+function minNullable(values: Array<number | null>): number | null {
+  let min: number | null = null;
+  for (const value of values) {
+    if (value === null) {
+      continue;
+    }
+    if (min === null || value < min) {
+      min = value;
+    }
+  }
+  return min;
+}
+
+function maxNullable(values: Array<number | null>): number | null {
+  let max: number | null = null;
+  for (const value of values) {
+    if (value === null) {
+      continue;
+    }
+    if (max === null || value > max) {
+      max = value;
+    }
+  }
+  return max;
+}
+
+function groupRowsByStatsId(rows: StatsSourceRow[]): Map<string, StatsSourceRow[]> {
+  const byStatsId = new Map<string, StatsSourceRow[]>();
+  for (const row of rows) {
+    const list = byStatsId.get(row.stats_id);
+    if (list === undefined) {
+      byStatsId.set(row.stats_id, [row]);
+    } else {
+      list.push(row);
+    }
+  }
+  return byStatsId;
+}
+
+// 隣接サンプルから正のビットレート (bps) を計算する。計算不能なら null
+function positiveBitrateBps(
+  prevBytes: number | null,
+  currBytes: number | null,
+  deltaMs: number,
+): number | null {
+  if (prevBytes === null || currBytes === null || deltaMs <= 0) {
+    return null;
+  }
+  const deltaBytes = currBytes - prevBytes;
+  if (deltaBytes <= 0) {
+    return null;
+  }
+  return (deltaBytes * 8 * 1000) / deltaMs;
+}
+
+function positiveRatesForStatsId(
+  sorted: StatsSourceRow[],
+  bytesKey: "bytes_sent" | "bytes_received",
+): number[] {
+  const positiveRates: number[] = [];
+  for (let index = 1; index < sorted.length; index += 1) {
+    const prev = sorted[index - 1];
+    const curr = sorted[index];
+    const rate = positiveBitrateBps(
+      prev[bytesKey],
+      curr[bytesKey],
+      curr.timestamp_ms - prev.timestamp_ms,
+    );
+    if (rate !== null) {
+      positiveRates.push(rate);
+    }
+  }
+  return positiveRates;
+}
+
+// stats_id 単位で bytes 差分 ÷ 時間差（秒）の正の値だけ平均する
+function averagePositiveBitrateBps(
+  rows: StatsSourceRow[],
+  bytesKey: "bytes_sent" | "bytes_received",
+): number | null {
+  const byStatsId = groupRowsByStatsId(rows);
+  const positiveRates: number[] = [];
+  for (const list of byStatsId.values()) {
+    const sorted = [...list].toSorted(compareByTimeThenId);
+    for (const rate of positiveRatesForStatsId(sorted, bytesKey)) {
+      positiveRates.push(rate);
+    }
+  }
+  if (positiveRates.length === 0) {
+    return null;
+  }
+  let total = 0;
+  for (const rate of positiveRates) {
+    total += rate;
+  }
+  return total / positiveRates.length;
+}
+
+function computePacketLossRate(
+  packetsReceived: number | null,
+  packetsLost: number | null,
+): number | null {
+  if (packetsReceived === null && packetsLost === null) {
+    return null;
+  }
+  const received = packetsReceived ?? 0;
+  const lost = packetsLost ?? 0;
+  const denominator = received + lost;
+  if (denominator === 0) {
+    return null;
+  }
+  return lost / denominator;
+}
+
+// 集計値を算出する（行が無ければ各フィールド null）
+export function computeStatsAggregates(rows: StatsSourceRow[]): StatsAggregates {
+  const inbound = rows.filter((row) => row.stats_type === "inbound-rtp");
+  const outbound = rows.filter((row) => row.stats_type === "outbound-rtp");
+  const candidatePairs = rows.filter((row) => row.stats_type === "candidate-pair");
+
+  const latestInbound = [...latestRowPerStatsId(inbound).values()];
+  const latestOutbound = [...latestRowPerStatsId(outbound).values()];
+  const latestPairs = [...latestRowPerStatsId(candidatePairs).values()];
+
+  const packetsReceived = sumNullable(latestInbound.map((row) => row.packets_received));
+  const packetsLost = sumNullable(latestInbound.map((row) => row.packets_lost));
+  const packetsSent = sumNullable(latestOutbound.map((row) => row.packets_sent));
+  const rttValues = latestPairs.map((row) => row.round_trip_time);
+
+  return {
+    packets_received: packetsReceived,
+    packets_sent: packetsSent,
+    packet_loss_rate: computePacketLossRate(packetsReceived, packetsLost),
+    rtt_min: minNullable(rttValues),
+    rtt_max: maxNullable(rttValues),
+    rtt_avg: averageNullable(rttValues),
+    bitrate_send_bps: averagePositiveBitrateBps(outbound, "bytes_sent"),
+    bitrate_recv_bps: averagePositiveBitrateBps(inbound, "bytes_received"),
+  };
+}
+
+interface StreamSample {
+  stats_id: string;
+  timestamp_ms: number;
+  id: number;
+  bitrate_send_bps: number | null;
+  bitrate_recv_bps: number | null;
+  round_trip_time: number | null;
+}
+
+function sampleBitratesFromAdjacent(
+  prev: StatsSourceRow,
+  curr: StatsSourceRow,
+): { bitrate_send_bps: number | null; bitrate_recv_bps: number | null } {
+  const deltaMs = curr.timestamp_ms - prev.timestamp_ms;
+  let bitrateSend: number | null = null;
+  let bitrateRecv: number | null = null;
+  if (curr.stats_type === "outbound-rtp") {
+    bitrateSend = positiveBitrateBps(prev.bytes_sent, curr.bytes_sent, deltaMs);
+  }
+  if (curr.stats_type === "inbound-rtp") {
+    bitrateRecv = positiveBitrateBps(prev.bytes_received, curr.bytes_received, deltaMs);
+  }
+  return { bitrate_send_bps: bitrateSend, bitrate_recv_bps: bitrateRecv };
+}
+
+// stats_id 単位の差分ビットレートと RTT サンプルを作る
+function buildStreamSamples(rows: StatsSourceRow[]): StreamSample[] {
+  const byStatsId = groupRowsByStatsId(rows);
+  const samples: StreamSample[] = [];
+  for (const list of byStatsId.values()) {
+    const sorted = [...list].toSorted(compareByTimeThenId);
+    for (const [index, curr] of sorted.entries()) {
+      let bitrateSend: number | null = null;
+      let bitrateRecv: number | null = null;
+      if (index > 0) {
+        const prev = sorted[index - 1];
+        const bitrates = sampleBitratesFromAdjacent(prev, curr);
+        bitrateSend = bitrates.bitrate_send_bps;
+        bitrateRecv = bitrates.bitrate_recv_bps;
+      }
+      let rtt: number | null = null;
+      if (curr.stats_type === "candidate-pair") {
+        rtt = curr.round_trip_time;
+      }
+      samples.push({
+        stats_id: curr.stats_id,
+        timestamp_ms: curr.timestamp_ms,
+        id: curr.id,
+        bitrate_send_bps: bitrateSend,
+        bitrate_recv_bps: bitrateRecv,
+        round_trip_time: rtt,
+      });
+    }
+  }
+  return samples;
+}
+
+// バケット内で stats_id 単位の last を取り、bitrate は合算・RTT は平均する
+function foldBucketSamples(samples: StreamSample[]): {
+  bitrate_send_bps: number | null;
+  bitrate_recv_bps: number | null;
+  round_trip_time: number | null;
+} {
+  // stats_id ごとに last（timestamp_ms 最大、同値なら id 最大）を選ぶ
+  const lastPerStatsId = new Map<string, StreamSample>();
+  for (const sample of samples) {
+    const existing = lastPerStatsId.get(sample.stats_id);
+    if (existing === undefined) {
+      lastPerStatsId.set(sample.stats_id, sample);
+      continue;
+    }
+    if (compareByTimeThenId(existing, sample) < 0) {
+      lastPerStatsId.set(sample.stats_id, sample);
+    }
+  }
+  const lastSamples = [...lastPerStatsId.values()];
+  return {
+    bitrate_send_bps: sumNullable(lastSamples.map((sample) => sample.bitrate_send_bps)),
+    bitrate_recv_bps: sumNullable(lastSamples.map((sample) => sample.bitrate_recv_bps)),
+    round_trip_time: averageNullable(lastSamples.map((sample) => sample.round_trip_time)),
+  };
+}
+
+// 時系列サンプリング。intervalSec は呼び出し側で 10 または 60 に限定する
+export function computeStatsTimeseries(
+  rows: StatsSourceRow[],
+  intervalSec: number,
+): StatsTimeseriesPoint[] {
+  if (rows.length === 0) {
+    return [];
+  }
+  const intervalMs = intervalSec * 1000;
+  const samples = buildStreamSamples(rows);
+  const buckets = new Map<number, StreamSample[]>();
+  for (const sample of samples) {
+    const bucket = Math.floor(sample.timestamp_ms / intervalMs);
+    const list = buckets.get(bucket);
+    if (list === undefined) {
+      buckets.set(bucket, [sample]);
+    } else {
+      list.push(sample);
+    }
+  }
+
+  const bucketKeys = [...buckets.keys()].toSorted((a, b) => a - b);
+  const points: StatsTimeseriesPoint[] = [];
+  for (const bucket of bucketKeys) {
+    const list = buckets.get(bucket);
+    if (list === undefined || list.length === 0) {
+      continue;
+    }
+    const folded = foldBucketSamples(list);
+    points.push({
+      timestamp_ms: bucket * intervalMs,
+      bitrate_send_bps: folded.bitrate_send_bps,
+      bitrate_recv_bps: folded.bitrate_recv_bps,
+      round_trip_time: folded.round_trip_time,
+    });
+  }
+  return points;
+}

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -21,18 +21,19 @@ test("ルーティング: Sessions ボタンで /sessions に遷移する", asyn
   await page.goto(`${BASE_URL}/devtools/`);
 
   await page.getByRole("button", { name: "Sessions" }).click();
-  await page.getByRole("heading", { name: "Sessions" }).waitFor({ timeout: 5000 });
+  await page.getByRole("heading", { name: "Sessions", exact: true }).waitFor({ timeout: 5000 });
+  await page.getByTestId("sessions-privacy-notice").waitFor({ timeout: 5000 });
   const pathname = await page.evaluate(() => globalThis.location.pathname);
   if (pathname !== "/sessions") {
     throw new Error(`expected pathname "/sessions", got "${pathname}"`);
   }
 });
 
-test("ルーティング: /sessions 直アクセスで仮ページが表示される", async ({ page }) => {
+test("ルーティング: /sessions 直アクセスで Sessions ページが表示される", async ({ page }) => {
   await page.goto(`${BASE_URL}/sessions`);
-  await page.getByRole("heading", { name: "Sessions" }).waitFor({ timeout: 5000 });
+  await page.getByRole("heading", { name: "Sessions", exact: true }).waitFor({ timeout: 5000 });
+  await page.getByTestId("sessions-privacy-notice").waitFor({ timeout: 5000 });
 });
-
 test("ルーティング: 既存 query が / で復元される", async ({ page }) => {
   const devtools = new DevtoolsPage(page);
   const channelId = "routing-test-channel";
@@ -80,7 +81,7 @@ test("ルーティング: SPA 遷移中も Sora 接続が維持される", async
   }
 
   await page.getByRole("button", { name: "Sessions" }).click();
-  await page.getByRole("heading", { name: "Sessions" }).waitFor({ timeout: 5000 });
+  await page.getByRole("heading", { name: "Sessions", exact: true }).waitFor({ timeout: 5000 });
 
   const sessionsTurnLabel = await turnUrlLabel.textContent();
   if (sessionsTurnLabel === "TURN URL") {

--- a/tests/sessions-page.test.ts
+++ b/tests/sessions-page.test.ts
@@ -1,0 +1,110 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import { requireSoraConnectionEnv } from "./helpers/env.ts";
+import {
+  awaitSessionDatabaseReady,
+  cleanupSessionDatabase,
+  waitForEndedAt,
+  waitForWebrtcStats,
+} from "./helpers/sessionDatabase.ts";
+import { DevtoolsPage } from "./pages/DevtoolsPage.ts";
+
+// OPFS 上の DB はオリジン共有のため、Sessions UI テストは直列実行する
+test.describe.configure({ mode: "serial" });
+
+const BASE_URL = "http://localhost:3333";
+
+async function connectAndPersist(
+  page: Page,
+  channelId: string,
+): Promise<{ connectionId: string; sessionDbId: number }> {
+  const env = requireSoraConnectionEnv();
+  const devtools = new DevtoolsPage(page);
+  await devtools.navigate({
+    role: "sendrecv",
+    channelId,
+    signalingUrlCandidates: [env.signalingUrl],
+    accessToken: env.accessToken,
+    videoCodecType: "VP9",
+  });
+  await awaitSessionDatabaseReady(page);
+  await devtools.connect();
+  await devtools.waitForConnection();
+  const connectionId = await devtools.getConnectionId();
+  expect(connectionId).toBeTruthy();
+  if (!connectionId) {
+    throw new Error("expected non-empty connection ID");
+  }
+  await page.waitForTimeout(1500);
+  await devtools.disconnect();
+  const ended = await waitForEndedAt(page, { connectionId });
+  await waitForWebrtcStats(page, {
+    connectionId,
+    sessionDbId: ended.session.id,
+    channelId,
+    minCount: 1,
+  });
+  return { connectionId, sessionDbId: ended.session.id };
+}
+
+test.describe("sessions page UI", () => {
+  test.beforeEach(async ({ page }) => {
+    await cleanupSessionDatabase(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupSessionDatabase(page);
+  });
+
+  test("接続切断後に一覧・フィルタ・詳細が表示され再接続で複数行を区別できる", async ({ page }) => {
+    const env = requireSoraConnectionEnv();
+    const channelId = `${env.channelIdPrefix}sessions-page-ui`;
+
+    const first = await connectAndPersist(page, channelId);
+    const second = await connectAndPersist(page, channelId);
+    expect(second.connectionId).not.toBe(first.connectionId);
+    expect(second.sessionDbId).not.toBe(first.sessionDbId);
+
+    // /sessions で一覧を確認する
+    await page.goto(`${BASE_URL}/sessions`);
+    await page.getByRole("heading", { name: "Sessions", exact: true }).waitFor({ timeout: 10_000 });
+    await page.getByTestId("sessions-privacy-notice").waitFor({ timeout: 5000 });
+    await page.getByTestId("session-list").waitFor({ timeout: 10_000 });
+
+    const firstRow = page.getByTestId(`session-row-${first.sessionDbId}`);
+    const secondRow = page.getByTestId(`session-row-${second.sessionDbId}`);
+    await firstRow.waitFor({ timeout: 10_000 });
+    await secondRow.waitFor({ timeout: 10_000 });
+    await expect(firstRow).toContainText(channelId);
+    await expect(secondRow).toContainText(channelId);
+
+    // 一覧に connectionId 必須カラムが無いこと
+    const listHeader = page.getByTestId("session-list").locator("thead");
+    await expect(listHeader).not.toContainText("connectionId");
+    await expect(listHeader).not.toContainText("connection_id");
+
+    // フィルタ QS（channelId）が効く
+    await page.goto(`${BASE_URL}/sessions?channelId=${encodeURIComponent(channelId)}`);
+    await page.getByTestId("session-list").waitFor({ timeout: 10_000 });
+    await firstRow.waitFor({ timeout: 10_000 });
+    await secondRow.waitFor({ timeout: 10_000 });
+
+    // 詳細で集計または時系列が見える
+    await secondRow.click();
+    await page.getByTestId("session-detail").waitFor({ timeout: 10_000 });
+    await expect(page.getByTestId("session-detail")).toHaveAttribute(
+      "data-session-db-id",
+      String(second.sessionDbId),
+    );
+    await page.getByTestId("connections-table").waitFor({ timeout: 10_000 });
+    // 集計または時系列に実データが見えること（厳密な数値一致は求めない）
+    await page.getByTestId("stats-aggregates").waitFor({ timeout: 10_000 });
+    await page.getByTestId("stats-timeseries").waitFor({ timeout: 10_000 });
+    const rawTable = page.getByTestId("stats-raw-table");
+    const aggregatesText = await page.getByTestId("stats-aggregates").textContent();
+    const hasAggregateValue = aggregatesText !== null && /\d/u.test(aggregatesText);
+    const hasRawRows = await rawTable.isVisible().catch(() => false);
+    expect(hasAggregateValue || hasRawRows).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

DuckDB 読み取り API と `/sessions` ページの一覧・詳細・フィルタ UI を実装し、永続化した過去セッションを確認できるようにする。

## 変更内容

- `sessionDatabase.ts` に `listSessions` / `getSession` / `queryStatsAggregates` / `queryStatsTimeseries` / `queryStatsPage` を追加する
- Sessions コンポーネント（Filter / List / Detail / StatsChart）とルートを実装する
- 3 状態判定・QS パース・集計/時系列の純粋関数と Vitest を追加する
- Playwright E2E（再接続区別含む）と仮ページ前提の ct / routing を追従する

## 完了条件

- [x] `/sessions` で過去セッションの一覧（session 行単位）が表示できること
- [x] 一覧に `connectionId` を必須表示していないこと
- [x] `sessionDbId` QS で詳細を開け、connections と webrtc stats の集計・時系列・生データが確認できること
- [x] クエリストリング絞り込みが機能すること
- [x] プライバシー文言 3 点が表示されること
- [x] 読み取り失敗時にページ内エラーが表示されること
- [x] 新規チャートライブラリ依存を追加していないこと
- [x] 同一 channelId の複数 sessions 行が一覧・詳細で区別できること
- [x] 仮ページ前提の ct / routing E2E が新 UI に追従していること
- [x] `vp build` / `vp test run` / `pnpm test:ct` / `pnpm test:e2e` / `vp check` が成功すること
- [x] `CHANGES.md` の `## develop` に `[ADD]` を記載すること

## 関連 issue

- issues/closed/0070-add-sessions-page-ui.md