### PR TITLE
Sessions の時系列表示と永続化まわりを改善する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,11 +13,21 @@
 
 - [ADD] /sessions ページに過去セッション一覧・詳細・フィルタ UI を実装する
   - @voluntas
+- [ADD] uPlot を導入して Sessions の時系列チャートを 1 秒単位で描画する
+  - @voluntas
+- [ADD] Sessions の生データを stats_type 別にグラフ表示できるようにする
+  - @voluntas
+- [UPDATE] Sessions の生データ表示をストリーム選択 + 差分メトリクスに試行変更する
+  - @voluntas
 - [ADD] WebRTC stats を DuckDB-Wasm + OPFS に永続化する
   - @voluntas
 - [ADD] DuckDB-Wasm + OPFS でセッション・接続メタデータを永続化する
   - @voluntas
 - [ADD] preact-iso を導入して /sessions ページへのルーティング基盤を追加する
+  - @voluntas
+- [UPDATE] Sessions ボタンをトグルにして /sessions と DevTools を往復できるようにする
+  - @voluntas
+- [FIX] DuckDB 初期化完了前の接続でセッションが永続化されない競合を修正する
   - @voluntas
 
 ### misc

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "apache-arrow": "17.0.0",
     "preact": "10.29.3",
     "preact-iso": "2.12.0",
-    "sora-js-sdk": "2026.1.0"
+    "sora-js-sdk": "2026.1.0",
+    "uplot": "1.6.32"
   },
   "devDependencies": {
     "@fast-check/vitest": "0.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       sora-js-sdk:
         specifier: 2026.1.0
         version: 2026.1.0
+      uplot:
+        specifier: 1.6.32
+        version: 1.6.32
     devDependencies:
       '@fast-check/vitest':
         specifier: 0.4.1
@@ -1651,6 +1654,9 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  uplot@1.6.32:
+    resolution: {integrity: sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==}
+
   vite-plus@0.2.4:
     resolution: {integrity: sha512-gaBBjOXIq9lLRU44oAYdIr99p+JBLX1kxs+l/6LqGgSXwcVKAdDa1boSrOTELqYCkQQ0fpppXUGWi9o6JDT5zw==}
     engines: {node: ^20.19.0 || ^22.18.0 || >=24.11.0}
@@ -3046,6 +3052,8 @@ snapshots:
       browserslist: 4.28.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uplot@1.6.32: {}
 
   vite-plus@0.2.4(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.0)(jiti@2.7.0)(typescript@7.0.2))(jiti@2.7.0)(jsdom@29.1.1)(typescript@7.0.2):
     dependencies:

--- a/src/chartFormat.test.ts
+++ b/src/chartFormat.test.ts
@@ -1,0 +1,17 @@
+import { assert, test } from "vite-plus/test";
+
+import { axisTimeLabelsJst, formatChartUnixSecJst } from "./components/Sessions/chartFormat.ts";
+
+test("formatChartUnixSecJst は JST の時刻を返す", () => {
+  // 2024-01-01T00:00:00Z = 2024-01-01 09:00:00 JST
+  assert.equal(formatChartUnixSecJst(1_704_067_200, false), "09:00:00");
+});
+
+test("formatChartUnixSecJst は日付付きも JST で返す", () => {
+  assert.equal(formatChartUnixSecJst(1_704_067_200, true), "01/01 09:00:00");
+});
+
+test("axisTimeLabelsJst は同一日内なら時刻のみ", () => {
+  const labels = axisTimeLabelsJst(null, [1_704_067_200, 1_704_067_260]);
+  assert.deepEqual(labels, ["09:00:00", "09:01:00"]);
+});

--- a/src/components/Header/SessionsButton.ct.tsx
+++ b/src/components/Header/SessionsButton.ct.tsx
@@ -4,18 +4,19 @@ import { render } from "vitest-browser-preact";
 
 import { setDebug, setDebugType } from "@/app/actions";
 import { resetState } from "@/app/signals";
+import DevTools from "@/DevTools";
 import Sessions from "@/routes/Sessions";
 
 import { SessionsButton } from "./SessionsButton";
 
-// 本番と同じ境界: LocationProvider 配下でボタンは Router 外、Sessions は Router 内
+// 本番と同じ境界: LocationProvider 配下でボタンは Router 外、ページは Router 内
 function RoutingHarness() {
   return (
     <LocationProvider>
       <SessionsButton />
       <ErrorBoundary>
         <Router>
-          {/* @ts-expect-error preact-iso Route の型定義が JSX 戻り値と不一致 */}
+          <Route path="/" component={DevTools} />
           <Route path="/sessions" component={Sessions} />
         </Router>
       </ErrorBoundary>
@@ -36,6 +37,10 @@ test("SessionsButton: クリックで /sessions に遷移し Sessions ページ�
   await screen.getByRole("button", { name: "Sessions" }).click();
 
   assert.equal(globalThis.location.pathname, "/sessions");
+  assert.equal(
+    screen.getByRole("button", { name: "Sessions" }).element().getAttribute("aria-pressed"),
+    "true",
+  );
 
   await vi.waitFor(
     () => {
@@ -43,5 +48,25 @@ test("SessionsButton: クリックで /sessions に遷移し Sessions ページ�
       assert.isNotNull(screen.getByTestId("sessions-privacy-notice").element());
     },
     { timeout: 5000 },
+  );
+});
+
+test("SessionsButton: /sessions 上でもう一度クリックすると / に戻る", async () => {
+  globalThis.history.replaceState(null, "", "/sessions");
+  const screen = render(<RoutingHarness />);
+
+  await vi.waitFor(
+    () => {
+      assert.isNotNull(screen.getByRole("heading", { name: "Sessions", exact: true }).element());
+    },
+    { timeout: 5000 },
+  );
+
+  await screen.getByRole("button", { name: "Sessions" }).click();
+
+  assert.equal(globalThis.location.pathname, "/");
+  assert.equal(
+    screen.getByRole("button", { name: "Sessions" }).element().getAttribute("aria-pressed"),
+    "false",
   );
 });

--- a/src/components/Header/SessionsButton.tsx
+++ b/src/components/Header/SessionsButton.tsx
@@ -1,9 +1,15 @@
 import { useLocation } from "preact-iso";
 
 export function SessionsButton() {
-  const { route } = useLocation();
+  const { path, route } = useLocation();
+  const onSessionsPage = path === "/sessions";
 
   const onClick = (): void => {
+    if (onSessionsPage) {
+      // DevTools に戻る（signals は残るので接続状態は維持される）
+      route("/");
+      return;
+    }
     route("/sessions");
   };
 
@@ -13,11 +19,18 @@ export function SessionsButton() {
     cursor-pointer select-none border
     transition-colors duration-150
   `;
-  const stateClasses =
-    "text-black bg-bs-light border-bs-light hover:bg-[#e2e6ea] hover:border-[#dae0e5]";
+  // debug と同じ付け方（白文字 + 塗りつぶし）。色だけ debug のピンクと被らないようにする
+  const stateClasses = onSessionsPage
+    ? "text-white bg-[#20c997] border-[#20c997] hover:bg-[#1aa179] hover:border-[#1aa179]"
+    : "text-black bg-bs-light border-bs-light hover:bg-[#e2e6ea] hover:border-[#dae0e5]";
 
   return (
-    <button type="button" className={`${baseClasses} ${stateClasses}`} onClick={onClick}>
+    <button
+      type="button"
+      className={`${baseClasses} ${stateClasses}`}
+      onClick={onClick}
+      aria-pressed={onSessionsPage}
+    >
       Sessions
     </button>
   );

--- a/src/components/Sessions/MetricTimeSeriesChart.tsx
+++ b/src/components/Sessions/MetricTimeSeriesChart.tsx
@@ -9,89 +9,55 @@ import {
   GRID_STROKE,
   axisCompactNumberLabels,
   axisTimeLabelsJst,
-  formatBitrate,
   formatChartUnixSecJst,
-  formatRttMs,
 } from "@/components/Sessions/chartFormat";
 import styles from "@/components/Sessions/StatsChart.module.css";
-import type { StatsTimeseriesPoint } from "@/statsQuery";
 
-export interface StatsChartProps {
-  points: StatsTimeseriesPoint[];
-  metric: "bitrate_send_bps" | "bitrate_recv_bps" | "round_trip_time";
-  title: string;
+export interface MetricPoint {
+  timestamp_ms: number;
+  value: number | null;
 }
 
-interface MetricStyle {
+export interface MetricTimeSeriesChartProps {
+  points: MetricPoint[];
+  title: string;
+  unitLabel: string;
   stroke: string;
   fill: string;
-  unitLabel: string;
-  // 保存値から表示値へ（bps→表示用、RTT 秒→ms など）
-  toDisplay: (value: number) => number;
   formatValue: (value: number) => string;
+  // 保存値 → 表示値（RTT 秒→ms など）
+  toDisplay?: (value: number) => number;
+  testId?: string;
 }
 
-const METRIC_STYLES: Record<StatsChartProps["metric"], MetricStyle> = {
-  bitrate_send_bps: {
-    stroke: "#0d6efd",
-    fill: "rgba(13, 110, 253, 0.12)",
-    unitLabel: "kbps / Mbps",
-    toDisplay: (value) => value,
-    formatValue: formatBitrate,
-  },
-  bitrate_recv_bps: {
-    stroke: "#198754",
-    fill: "rgba(25, 135, 84, 0.12)",
-    unitLabel: "kbps / Mbps",
-    toDisplay: (value) => value,
-    formatValue: formatBitrate,
-  },
-  round_trip_time: {
-    stroke: "#fd7e14",
-    fill: "rgba(253, 126, 20, 0.12)",
-    unitLabel: "ms",
-    // WebRTC の roundTripTime は秒
-    toDisplay: (value) => value * 1000,
-    formatValue: formatRttMs,
-  },
-};
-
-function metricValue(
-  point: StatsTimeseriesPoint,
-  metric: StatsChartProps["metric"],
-): number | null {
-  if (metric === "bitrate_send_bps") {
-    return point.bitrate_send_bps;
-  }
-  if (metric === "bitrate_recv_bps") {
-    return point.bitrate_recv_bps;
-  }
-  return point.round_trip_time;
-}
-
-function hasPlottableValue(
-  points: StatsTimeseriesPoint[],
-  metric: StatsChartProps["metric"],
-): boolean {
+function hasPlottableValue(points: MetricPoint[]): boolean {
   for (const point of points) {
-    if (metricValue(point, metric) !== null) {
+    if (point.value !== null) {
       return true;
     }
   }
   return false;
 }
 
-// uPlot で時系列メトリクスを描画する（横軸は JST の実時刻）
-export const StatsChart: FunctionComponent<StatsChartProps> = ({ points, metric, title }) => {
+// 単一系列の汎用時系列チャート（試行用）
+export const MetricTimeSeriesChart: FunctionComponent<MetricTimeSeriesChartProps> = ({
+  points,
+  title,
+  unitLabel,
+  stroke,
+  fill,
+  formatValue,
+  toDisplay,
+  testId,
+}) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const style = METRIC_STYLES[metric];
 
   useEffect(() => {
     const container = containerRef.current;
     if (container === null) {
       return;
     }
-    if (!hasPlottableValue(points, metric)) {
+    if (!hasPlottableValue(points)) {
       return;
     }
 
@@ -99,25 +65,16 @@ export const StatsChart: FunctionComponent<StatsChartProps> = ({ points, metric,
     const values: Array<number | null> = [];
     for (const point of points) {
       timestampsSec.push(point.timestamp_ms / 1000);
-      const raw = metricValue(point, metric);
-      if (raw === null) {
+      if (point.value === null) {
         values.push(null);
+      } else if (toDisplay !== undefined) {
+        values.push(toDisplay(point.value));
       } else {
-        values.push(style.toDisplay(raw));
+        values.push(point.value);
       }
     }
 
     const width = Math.max(container.clientWidth, 320);
-    const yValues =
-      metric === "round_trip_time"
-        ? {
-            values: (_uPlot: UPlot, splits: number[]) =>
-              splits.map((value) => `${Math.round(value)}`),
-          }
-        : {
-            values: axisCompactNumberLabels,
-          };
-
     const plot = new UPlot(
       {
         width,
@@ -139,7 +96,6 @@ export const StatsChart: FunctionComponent<StatsChartProps> = ({ points, metric,
             time: true,
           },
           y: {
-            // 下限を 0 に寄せて読みやすくする
             range: (_uPlot, _initMin, initMax) => {
               const paddedMax = !Number.isFinite(initMax) || initMax <= 0 ? 1 : initMax * 1.08;
               return [0, paddedMax];
@@ -171,7 +127,7 @@ export const StatsChart: FunctionComponent<StatsChartProps> = ({ points, metric,
               stroke: GRID_STROKE,
             },
             size: 56,
-            ...yValues,
+            values: axisCompactNumberLabels,
           },
         ],
         series: [
@@ -186,8 +142,8 @@ export const StatsChart: FunctionComponent<StatsChartProps> = ({ points, metric,
           },
           {
             label: title,
-            stroke: style.stroke,
-            fill: style.fill,
+            stroke,
+            fill,
             width: 2,
             spanGaps: false,
             points: {
@@ -197,7 +153,7 @@ export const StatsChart: FunctionComponent<StatsChartProps> = ({ points, metric,
               if (!Number.isFinite(value)) {
                 return "—";
               }
-              return style.formatValue(value);
+              return formatValue(value);
             },
           },
         ],
@@ -218,17 +174,16 @@ export const StatsChart: FunctionComponent<StatsChartProps> = ({ points, metric,
       resizeObserver.disconnect();
       plot.destroy();
     };
-  }, [points, metric, title, style]);
+  }, [points, title, stroke, fill, unitLabel, formatValue, toDisplay]);
 
-  if (!hasPlottableValue(points, metric)) {
+  const resolvedTestId = testId ?? "metric-timeseries-chart";
+
+  if (!hasPlottableValue(points)) {
     return (
-      <div
-        className="rounded border border-bs-light bg-white p-3"
-        data-testid={`stats-chart-${metric}`}
-      >
+      <div className="rounded border border-bs-light bg-white p-3" data-testid={resolvedTestId}>
         <div className="mb-1 flex items-baseline justify-between gap-2">
           <h4 className="text-sm font-semibold text-bs-body">{title}</h4>
-          <span className="text-xs text-bs-secondary">{style.unitLabel}</span>
+          <span className="text-xs text-bs-secondary">{unitLabel}</span>
         </div>
         <p className="text-sm text-bs-secondary">表示できる時系列データがありません</p>
       </div>
@@ -236,19 +191,16 @@ export const StatsChart: FunctionComponent<StatsChartProps> = ({ points, metric,
   }
 
   return (
-    <div
-      className="rounded border border-bs-light bg-white p-3"
-      data-testid={`stats-chart-${metric}`}
-    >
+    <div className="rounded border border-bs-light bg-white p-3" data-testid={resolvedTestId}>
       <div className="mb-2 flex items-baseline justify-between gap-2">
         <h4 className="text-sm font-semibold text-bs-body">{title}</h4>
-        <span className="text-xs text-bs-secondary">{style.unitLabel}</span>
+        <span className="text-xs text-bs-secondary">{unitLabel}</span>
       </div>
       <div
         ref={containerRef}
         className={styles.chart}
         role="img"
-        aria-label={`${title}（単位: ${style.unitLabel}）`}
+        aria-label={`${title}（単位: ${unitLabel}）`}
       />
     </div>
   );

--- a/src/components/Sessions/RawStatsChart.tsx
+++ b/src/components/Sessions/RawStatsChart.tsx
@@ -1,0 +1,231 @@
+import type { FunctionComponent } from "preact";
+import { useEffect, useRef } from "preact/hooks";
+import UPlot from "uplot";
+import "uplot/dist/uPlot.min.css";
+
+import {
+  AXIS_STROKE,
+  CHART_HEIGHT,
+  GRID_STROKE,
+  SERIES_COLORS,
+  axisCompactNumberLabels,
+  axisTimeLabelsJst,
+  formatByteCount,
+  formatChartUnixSecJst,
+  formatCount,
+  formatRttMs,
+} from "@/components/Sessions/chartFormat";
+import styles from "@/components/Sessions/StatsChart.module.css";
+import type { StatsRawMetric, StatsRawSeriesPoint } from "@/sessionDatabase";
+import { alignRawSeriesPoints, maxRawSeriesCount } from "@/statsRawSeries";
+
+export interface RawStatsChartProps {
+  points: StatsRawSeriesPoint[];
+  metric: StatsRawMetric;
+  title: string;
+}
+
+function toDisplayValue(metric: StatsRawMetric, value: number): number {
+  if (metric === "round_trip_time") {
+    return value * 1000;
+  }
+  return value;
+}
+
+function formatMetricValue(metric: StatsRawMetric, value: number): string {
+  if (metric === "round_trip_time") {
+    return formatRttMs(value);
+  }
+  if (metric === "bytes_sent" || metric === "bytes_received") {
+    return formatByteCount(value);
+  }
+  return formatCount(value);
+}
+
+function unitLabel(metric: StatsRawMetric): string {
+  if (metric === "round_trip_time") {
+    return "ms";
+  }
+  if (metric === "bytes_sent" || metric === "bytes_received") {
+    return "B / KB / MB";
+  }
+  return "packets";
+}
+
+function hasPlottablePoints(points: StatsRawSeriesPoint[]): boolean {
+  return points.length > 0;
+}
+
+// 生データの stats_id 別時系列を uPlot で描画する
+export const RawStatsChart: FunctionComponent<RawStatsChartProps> = ({ points, metric, title }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const distinctIds = new Set(points.map((point) => point.stats_id)).size;
+  const truncated = distinctIds > maxRawSeriesCount();
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (container === null) {
+      return;
+    }
+    if (!hasPlottablePoints(points)) {
+      return;
+    }
+
+    const aligned = alignRawSeriesPoints(points);
+    if (aligned.series.length === 0 || aligned.timestampsSec.length === 0) {
+      return;
+    }
+
+    const displaySeries = aligned.series.map((entry) => ({
+      statsId: entry.statsId,
+      values: entry.values.map((value) => {
+        if (value === null) {
+          return null;
+        }
+        return toDisplayValue(metric, value);
+      }),
+    }));
+
+    const width = Math.max(container.clientWidth, 320);
+    const seriesOpts: UPlot.Series[] = [
+      {
+        label: "時刻 (JST)",
+        value: (_uPlot, unixSec) => {
+          if (!Number.isFinite(unixSec)) {
+            return "—";
+          }
+          return formatChartUnixSecJst(unixSec, true);
+        },
+      },
+    ];
+    for (const [index, entry] of displaySeries.entries()) {
+      const color = SERIES_COLORS[index % SERIES_COLORS.length];
+      seriesOpts.push({
+        label: entry.statsId,
+        stroke: color,
+        width: 2,
+        spanGaps: false,
+        points: {
+          show: false,
+        },
+        value: (_uPlot, value) => {
+          if (!Number.isFinite(value)) {
+            return "—";
+          }
+          return formatMetricValue(metric, value);
+        },
+      });
+    }
+
+    const data: UPlot.AlignedData = [
+      aligned.timestampsSec,
+      ...displaySeries.map((entry) => entry.values),
+    ];
+
+    const plot = new UPlot(
+      {
+        width,
+        height: CHART_HEIGHT,
+        padding: [8, 12, 0, 8],
+        cursor: {
+          show: true,
+          points: {
+            size: 7,
+            width: 2,
+          },
+        },
+        legend: {
+          show: true,
+          live: true,
+        },
+        scales: {
+          x: {
+            time: true,
+          },
+          y: {
+            range: (_uPlot, _initMin, initMax) => {
+              const paddedMax = !Number.isFinite(initMax) || initMax <= 0 ? 1 : initMax * 1.08;
+              return [0, paddedMax];
+            },
+          },
+        },
+        axes: [
+          {
+            stroke: AXIS_STROKE,
+            grid: {
+              show: true,
+              stroke: GRID_STROKE,
+              width: 1,
+            },
+            ticks: {
+              stroke: GRID_STROKE,
+            },
+            values: axisTimeLabelsJst,
+            space: 72,
+          },
+          {
+            stroke: AXIS_STROKE,
+            grid: {
+              show: true,
+              stroke: GRID_STROKE,
+              width: 1,
+            },
+            ticks: {
+              stroke: GRID_STROKE,
+            },
+            size: 64,
+            values: axisCompactNumberLabels,
+          },
+        ],
+        series: seriesOpts,
+      },
+      data,
+      container,
+    );
+
+    const resizeObserver = new ResizeObserver(() => {
+      const nextWidth = Math.max(container.clientWidth, 320);
+      if (nextWidth !== plot.width) {
+        plot.setSize({ width: nextWidth, height: CHART_HEIGHT });
+      }
+    });
+    resizeObserver.observe(container);
+
+    return () => {
+      resizeObserver.disconnect();
+      plot.destroy();
+    };
+  }, [points, metric]);
+
+  if (!hasPlottablePoints(points)) {
+    return (
+      <div className="rounded border border-bs-light bg-white p-3" data-testid="raw-stats-chart">
+        <div className="mb-1 flex items-baseline justify-between gap-2">
+          <h4 className="text-sm font-semibold text-bs-body">{title}</h4>
+          <span className="text-xs text-bs-secondary">{unitLabel(metric)}</span>
+        </div>
+        <p className="text-sm text-bs-secondary">表示できる生データ時系列がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded border border-bs-light bg-white p-3" data-testid="raw-stats-chart">
+      <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+        <h4 className="text-sm font-semibold text-bs-body">{title}</h4>
+        <span className="text-xs text-bs-secondary">{unitLabel(metric)}</span>
+      </div>
+      {truncated ? (
+        <p className="mb-2 text-xs text-bs-secondary">
+          stats_id が多いため上位 {String(maxRawSeriesCount())} 系列のみ表示しています
+        </p>
+      ) : null}
+      <div
+        ref={containerRef}
+        className={styles.chart}
+        role="img"
+        aria-label={`${title}（単位: ${unitLabel(metric)}）`}
+      />
+    </div>
+  );
+};

--- a/src/components/Sessions/SessionDetail.tsx
+++ b/src/components/Sessions/SessionDetail.tsx
@@ -2,11 +2,11 @@ import type { FunctionComponent } from "preact";
 import { useEffect, useState } from "preact/hooks";
 
 import { StatsChart } from "@/components/Sessions/StatsChart";
+import { StatsRawPanel } from "@/components/Sessions/StatsRawPanel";
 import {
   getCurrentSessionDbId,
   getSession,
   queryStatsAggregates,
-  queryStatsPage,
   queryStatsTimeseries,
   whenReady,
 } from "@/sessionDatabase";
@@ -14,7 +14,6 @@ import type {
   ConnectionListRow,
   SessionDetail as SessionDetailData,
   StatsAggregates,
-  StatsPageResult,
   StatsTimeseriesPoint,
 } from "@/sessionDatabase";
 import { deriveSessionStatus, sessionStatusLabel } from "@/sessionStatus";
@@ -42,19 +41,15 @@ export const SessionDetail: FunctionComponent<SessionDetailProps> = ({ sessionDb
   const [detail, setDetail] = useState<SessionDetailData | null>(null);
   const [aggregates, setAggregates] = useState<StatsAggregates | null>(null);
   const [timeseries, setTimeseries] = useState<StatsTimeseriesPoint[]>([]);
-  const [statsPage, setStatsPage] = useState<StatsPageResult>({ rows: [], totalCount: 0 });
-  const [intervalSec, setIntervalSec] = useState<10 | 60>(10);
-  const [pageOffset, setPageOffset] = useState(0);
+  const [intervalSec, setIntervalSec] = useState<1 | 10 | 60>(1);
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const pageLimit = 50;
 
   useEffect(() => {
     if (sessionDbId === undefined) {
       setDetail(null);
       setAggregates(null);
       setTimeseries([]);
-      setStatsPage({ rows: [], totalCount: 0 });
       setErrorMessage(null);
       return;
     }
@@ -79,14 +74,12 @@ export const SessionDetail: FunctionComponent<SessionDetailProps> = ({ sessionDb
           setDetail(null);
           setAggregates(null);
           setTimeseries([]);
-          setStatsPage({ rows: [], totalCount: 0 });
           setLoading(false);
           return;
         }
-        const [agg, series, page] = await Promise.all([
+        const [agg, series] = await Promise.all([
           queryStatsAggregates(sessionDbId),
           queryStatsTimeseries(sessionDbId, { intervalSec }),
-          queryStatsPage(sessionDbId, { limit: pageLimit, offset: pageOffset }),
         ]);
         // await 中に cleanup で cancelled が立つ可能性がある
         // oxlint-disable-next-line typescript/no-unnecessary-condition
@@ -96,7 +89,6 @@ export const SessionDetail: FunctionComponent<SessionDetailProps> = ({ sessionDb
         setDetail(loaded);
         setAggregates(agg);
         setTimeseries(series);
-        setStatsPage(page);
         setLoading(false);
       } catch (error) {
         if (active.cancelled) {
@@ -112,7 +104,7 @@ export const SessionDetail: FunctionComponent<SessionDetailProps> = ({ sessionDb
     return () => {
       active.cancelled = true;
     };
-  }, [sessionDbId, intervalSec, pageOffset]);
+  }, [sessionDbId, intervalSec]);
 
   if (sessionDbId === undefined) {
     return (
@@ -156,7 +148,6 @@ export const SessionDetail: FunctionComponent<SessionDetailProps> = ({ sessionDb
     detail.session.id,
     currentSessionDbId,
   );
-  const maxOffset = Math.max(0, statsPage.totalCount - pageLimit);
 
   return (
     <div data-testid="session-detail" data-session-db-id={String(detail.session.id)}>
@@ -238,61 +229,39 @@ export const SessionDetail: FunctionComponent<SessionDetailProps> = ({ sessionDb
         </dl>
       )}
 
-      <div className="mb-2 flex items-center gap-2">
-        <h3 className="text-base font-semibold">時系列</h3>
-        <label className="text-sm">
-          間隔
+      <div className="mb-3 flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <h3 className="text-base font-semibold">時系列</h3>
+          <p className="mt-0.5 text-xs text-bs-secondary">
+            getStats は 1 秒間隔。横軸は JST の実時刻
+          </p>
+        </div>
+        <label className="text-sm text-bs-secondary">
+          表示間隔
           <select
-            className="ml-2 rounded border border-bs-secondary px-2 py-1"
+            className="ml-2 rounded border border-bs-secondary bg-white px-2 py-1 text-bs-body"
             value={String(intervalSec)}
             data-testid="timeseries-interval"
             onChange={(event) => {
               const next = Number(event.currentTarget.value);
-              if (next === 10 || next === 60) {
+              if (next === 1 || next === 10 || next === 60) {
                 setIntervalSec(next);
               }
             }}
           >
+            <option value="1">1 秒</option>
             <option value="10">10 秒</option>
             <option value="60">1 分</option>
           </select>
         </label>
       </div>
-      <div data-testid="stats-timeseries">
-        <StatsChart points={timeseries} metric="bitrate_send_bps" title="送信ビットレート (bps)" />
-        <StatsChart points={timeseries} metric="bitrate_recv_bps" title="受信ビットレート (bps)" />
-        <StatsChart points={timeseries} metric="round_trip_time" title="RTT (秒)" />
+      <div className="flex flex-col gap-4" data-testid="stats-timeseries">
+        <StatsChart points={timeseries} metric="bitrate_send_bps" title="送信ビットレート" />
+        <StatsChart points={timeseries} metric="bitrate_recv_bps" title="受信ビットレート" />
+        <StatsChart points={timeseries} metric="round_trip_time" title="RTT" />
       </div>
 
-      <h3 className="mb-2 mt-4 text-base font-semibold">生データ</h3>
-      <p className="mb-2 text-sm text-bs-secondary" data-testid="stats-page-count">
-        全 {statsPage.totalCount} 件（offset {pageOffset}）
-      </p>
-      <div className="mb-2 flex gap-2">
-        <button
-          type="button"
-          className="rounded border border-bs-secondary px-2 py-1 text-sm disabled:opacity-50"
-          disabled={pageOffset <= 0}
-          data-testid="stats-page-prev"
-          onClick={() => {
-            setPageOffset(Math.max(0, pageOffset - pageLimit));
-          }}
-        >
-          前へ
-        </button>
-        <button
-          type="button"
-          className="rounded border border-bs-secondary px-2 py-1 text-sm disabled:opacity-50"
-          disabled={pageOffset >= maxOffset}
-          data-testid="stats-page-next"
-          onClick={() => {
-            setPageOffset(Math.min(maxOffset, pageOffset + pageLimit));
-          }}
-        >
-          次へ
-        </button>
-      </div>
-      <StatsRawTable page={statsPage} />
+      <StatsRawPanel sessionDbId={detail.session.id} />
     </div>
   );
 };
@@ -331,50 +300,6 @@ const ConnectionsTable: FunctionComponent<{ connections: ConnectionListRow[] }> 
                 {displayOrDash(connection.started_at)}
               </td>
               <td className="px-2 py-1 font-mono text-xs">{displayOrDash(connection.ended_at)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-};
-
-const StatsRawTable: FunctionComponent<{ page: StatsPageResult }> = ({ page }) => {
-  if (page.rows.length === 0) {
-    return (
-      <p className="text-sm text-bs-secondary" data-testid="stats-raw-empty">
-        生データはありません
-      </p>
-    );
-  }
-  return (
-    <div className="overflow-x-auto" data-testid="stats-raw-table">
-      <table className="w-full border-collapse text-left text-xs">
-        <thead>
-          <tr className="border-b border-bs-secondary">
-            <th className="px-2 py-1">timestamp_ms</th>
-            <th className="px-2 py-1">stats_type</th>
-            <th className="px-2 py-1">stats_id</th>
-            <th className="px-2 py-1">kind</th>
-            <th className="px-2 py-1">packets_received</th>
-            <th className="px-2 py-1">packets_sent</th>
-            <th className="px-2 py-1">bytes_received</th>
-            <th className="px-2 py-1">bytes_sent</th>
-            <th className="px-2 py-1">round_trip_time</th>
-          </tr>
-        </thead>
-        <tbody>
-          {page.rows.map((row) => (
-            <tr key={row.id} className="border-b border-bs-light">
-              <td className="px-2 py-1 font-mono">{displayOrDash(row.timestamp_ms)}</td>
-              <td className="px-2 py-1">{displayOrDash(row.stats_type)}</td>
-              <td className="px-2 py-1 font-mono">{displayOrDash(row.stats_id)}</td>
-              <td className="px-2 py-1">{displayOrDash(row.kind)}</td>
-              <td className="px-2 py-1">{displayOrDash(row.packets_received)}</td>
-              <td className="px-2 py-1">{displayOrDash(row.packets_sent)}</td>
-              <td className="px-2 py-1">{displayOrDash(row.bytes_received)}</td>
-              <td className="px-2 py-1">{displayOrDash(row.bytes_sent)}</td>
-              <td className="px-2 py-1">{displayOrDash(row.round_trip_time)}</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/Sessions/StatsChart.module.css
+++ b/src/components/Sessions/StatsChart.module.css
@@ -1,0 +1,28 @@
+.chart {
+  width: 100%;
+}
+
+.chart :global(.uplot) {
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    sans-serif;
+}
+
+.chart :global(.u-legend) {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: #495057;
+}
+
+.chart :global(.u-legend .u-series) {
+  margin-right: 0.75rem;
+}
+
+.chart :global(.u-legend .u-value) {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: #212529;
+}

--- a/src/components/Sessions/StatsRawPanel.tsx
+++ b/src/components/Sessions/StatsRawPanel.tsx
@@ -1,0 +1,488 @@
+import type { FunctionComponent } from "preact";
+import { useEffect, useState } from "preact/hooks";
+
+import {
+  formatBitrate,
+  formatByteCount,
+  formatChartUnixSecJst,
+  formatCount,
+  formatRttMs,
+} from "@/components/Sessions/chartFormat";
+import { MetricTimeSeriesChart } from "@/components/Sessions/MetricTimeSeriesChart";
+import { queryStatsPage, queryStatsStreamTimeseries, queryStatsStreams } from "@/sessionDatabase";
+import type {
+  StatsPageResult,
+  StatsStreamSummary,
+  StatsStreamTimeseriesPoint,
+} from "@/sessionDatabase";
+
+export interface StatsRawPanelProps {
+  sessionDbId: number;
+}
+
+function displayOrDash(value: string | number | null | undefined): string {
+  if (value === null || value === undefined || value === "") {
+    return "—";
+  }
+  return String(value);
+}
+
+function formatTableNumber(value: number | null): string {
+  if (value === null) {
+    return "—";
+  }
+  return formatCount(value);
+}
+
+function formatTableBytes(value: number | null): string {
+  if (value === null) {
+    return "—";
+  }
+  return formatByteCount(value);
+}
+
+function formatTableRtt(value: number | null): string {
+  if (value === null) {
+    return "—";
+  }
+  return formatRttMs(value * 1000);
+}
+
+function formatPacketRate(pps: number): string {
+  if (pps >= 100) {
+    return `${Math.round(pps)} pps`;
+  }
+  return `${pps.toFixed(1)} pps`;
+}
+
+function rttSecondsToMs(value: number): number {
+  return value * 1000;
+}
+
+function streamTypeLabel(statsType: string): string {
+  if (statsType === "outbound-rtp") {
+    return "送信";
+  }
+  if (statsType === "inbound-rtp") {
+    return "受信";
+  }
+  if (statsType === "candidate-pair") {
+    return "RTT";
+  }
+  return statsType;
+}
+
+function shortStatsId(statsId: string): string {
+  if (statsId.length <= 28) {
+    return statsId;
+  }
+  return `${statsId.slice(0, 12)}…${statsId.slice(-10)}`;
+}
+
+function pickDefaultStream(streams: StatsStreamSummary[]): StatsStreamSummary | null {
+  if (streams.length === 0) {
+    return null;
+  }
+  const preferredOrder = ["outbound-rtp", "inbound-rtp", "candidate-pair"];
+  for (const preferred of preferredOrder) {
+    for (const stream of streams) {
+      if (stream.stats_type === preferred) {
+        return stream;
+      }
+    }
+  }
+  return streams[0] ?? null;
+}
+
+// ストリーム選択 → 差分メトリクスグラフ → 折りたたみ生テーブル（試行 UI）
+export const StatsRawPanel: FunctionComponent<StatsRawPanelProps> = ({ sessionDbId }) => {
+  const [streams, setStreams] = useState<StatsStreamSummary[]>([]);
+  const [selectedStatsId, setSelectedStatsId] = useState("");
+  const [timeseries, setTimeseries] = useState<StatsStreamTimeseriesPoint[]>([]);
+  const [page, setPage] = useState<StatsPageResult>({ rows: [], totalCount: 0 });
+  const [pageOffset, setPageOffset] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const pageLimit = 50;
+
+  const selected = streams.find((stream) => stream.stats_id === selectedStatsId) ?? null;
+
+  // ストリーム一覧
+  useEffect(() => {
+    const active = { cancelled: false };
+    setLoading(true);
+    setErrorMessage(null);
+    void (async () => {
+      try {
+        const listed = await queryStatsStreams(sessionDbId);
+        if (active.cancelled) {
+          return;
+        }
+        setStreams(listed);
+        const initial = pickDefaultStream(listed);
+        setSelectedStatsId(initial?.stats_id ?? "");
+        setPageOffset(0);
+        setLoading(false);
+      } catch (error) {
+        if (active.cancelled) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : "Failed to list stats streams";
+        console.warn(`Stats streams load failed: ${message}`);
+        setErrorMessage(message);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      active.cancelled = true;
+    };
+  }, [sessionDbId]);
+
+  // 選択ストリームの時系列 + 生テーブル
+  useEffect(() => {
+    if (selectedStatsId === "") {
+      setTimeseries([]);
+      setPage({ rows: [], totalCount: 0 });
+      return;
+    }
+    const active = { cancelled: false };
+    setLoading(true);
+    setErrorMessage(null);
+    void (async () => {
+      try {
+        const [series, pageResult] = await Promise.all([
+          queryStatsStreamTimeseries(sessionDbId, selectedStatsId),
+          queryStatsPage(sessionDbId, {
+            limit: pageLimit,
+            offset: pageOffset,
+            statsId: selectedStatsId,
+          }),
+        ]);
+        if (active.cancelled) {
+          return;
+        }
+        setTimeseries(series);
+        setPage(pageResult);
+        setLoading(false);
+      } catch (error) {
+        if (active.cancelled) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : "Failed to load stream stats";
+        console.warn(`Stats stream detail load failed: ${message}`);
+        setErrorMessage(message);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      active.cancelled = true;
+    };
+  }, [sessionDbId, selectedStatsId, pageOffset]);
+
+  const maxOffset = Math.max(0, page.totalCount - pageLimit);
+  const showBitrate =
+    selected?.stats_type === "outbound-rtp" || selected?.stats_type === "inbound-rtp";
+  const showPacketRate = showBitrate;
+  const showRtt = selected?.stats_type === "candidate-pair";
+
+  return (
+    <section className="mt-4" data-testid="stats-raw-panel">
+      <div className="mb-3">
+        <h3 className="text-base font-semibold">ストリーム詳細</h3>
+        <p className="mt-0.5 text-xs text-bs-secondary">
+          stats_id を選ぶと、累積値ではなく差分から求めたビットレート / パケットレート / RTT
+          を表示します（試行中）
+        </p>
+      </div>
+
+      {errorMessage !== null ? (
+        <p className="mb-2 text-sm text-red-700" data-testid="raw-stats-error">
+          {errorMessage}
+        </p>
+      ) : null}
+      {loading ? (
+        <p className="mb-2 text-sm text-bs-secondary" data-testid="raw-stats-loading">
+          読み込み中…
+        </p>
+      ) : null}
+
+      {streams.length === 0 && !loading ? (
+        <p className="text-sm text-bs-secondary" data-testid="stats-streams-empty">
+          表示できるストリームがありません
+        </p>
+      ) : (
+        <div className="mb-4 grid grid-cols-1 gap-4 lg:grid-cols-[minmax(240px,320px)_1fr]">
+          <div
+            className="max-h-96 overflow-auto rounded border border-bs-light"
+            data-testid="stats-stream-list"
+          >
+            <ul className="divide-y divide-bs-light">
+              {streams.map((stream) => {
+                const active = stream.stats_id === selectedStatsId;
+                const summaryParts: string[] = [];
+                if (stream.kind !== null) {
+                  summaryParts.push(stream.kind);
+                }
+                if (stream.last_bitrate_bps !== null) {
+                  summaryParts.push(formatBitrate(stream.last_bitrate_bps));
+                }
+                if (stream.last_packet_rate_pps !== null) {
+                  summaryParts.push(formatPacketRate(stream.last_packet_rate_pps));
+                }
+                if (stream.last_round_trip_time !== null) {
+                  summaryParts.push(formatRttMs(stream.last_round_trip_time * 1000));
+                }
+                summaryParts.push(`${String(stream.sample_count)} samples`);
+                return (
+                  <li key={`${stream.stats_type}:${stream.stats_id}`}>
+                    <button
+                      type="button"
+                      className={
+                        active
+                          ? "w-full bg-[#e7f1ff] px-3 py-2 text-left"
+                          : "w-full bg-white px-3 py-2 text-left hover:bg-[#f8f9fa]"
+                      }
+                      data-testid="stats-stream-item"
+                      data-stats-id={stream.stats_id}
+                      aria-pressed={active}
+                      onClick={() => {
+                        setSelectedStatsId(stream.stats_id);
+                        setPageOffset(0);
+                      }}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="rounded bg-bs-light px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-bs-secondary uppercase">
+                          {streamTypeLabel(stream.stats_type)}
+                        </span>
+                        <span
+                          className="truncate font-mono text-xs text-bs-body"
+                          title={stream.stats_id}
+                        >
+                          {shortStatsId(stream.stats_id)}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-bs-secondary">{summaryParts.join(" · ")}</p>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          <div className="flex min-w-0 flex-col gap-3" data-testid="stats-stream-detail">
+            {selected === null ? (
+              <p className="text-sm text-bs-secondary">ストリームを選択してください</p>
+            ) : (
+              <>
+                <div className="rounded border border-bs-light bg-white p-3">
+                  <p className="text-xs text-bs-secondary">選択中</p>
+                  <p className="font-mono text-sm break-all">{selected.stats_id}</p>
+                  <p className="mt-1 text-xs text-bs-secondary">
+                    {streamTypeLabel(selected.stats_type)}
+                    {selected.kind !== null ? ` / ${selected.kind}` : ""}
+                    {` / ${String(selected.sample_count)} samples`}
+                  </p>
+                </div>
+                {showBitrate ? (
+                  <MetricTimeSeriesChart
+                    points={timeseries.map((point) => ({
+                      timestamp_ms: point.timestamp_ms,
+                      value: point.bitrate_bps,
+                    }))}
+                    title="ビットレート（差分）"
+                    unitLabel="kbps / Mbps"
+                    stroke="#0d6efd"
+                    fill="rgba(13, 110, 253, 0.12)"
+                    formatValue={formatBitrate}
+                    testId="stream-chart-bitrate"
+                  />
+                ) : null}
+                {showPacketRate ? (
+                  <MetricTimeSeriesChart
+                    points={timeseries.map((point) => ({
+                      timestamp_ms: point.timestamp_ms,
+                      value: point.packet_rate_pps,
+                    }))}
+                    title="パケットレート（差分）"
+                    unitLabel="pps"
+                    stroke="#198754"
+                    fill="rgba(25, 135, 84, 0.12)"
+                    formatValue={formatPacketRate}
+                    testId="stream-chart-packet-rate"
+                  />
+                ) : null}
+                {showRtt ? (
+                  <MetricTimeSeriesChart
+                    points={timeseries.map((point) => ({
+                      timestamp_ms: point.timestamp_ms,
+                      value: point.round_trip_time,
+                    }))}
+                    title="RTT"
+                    unitLabel="ms"
+                    stroke="#fd7e14"
+                    fill="rgba(253, 126, 20, 0.12)"
+                    formatValue={formatRttMs}
+                    toDisplay={rttSecondsToMs}
+                    testId="stream-chart-rtt"
+                  />
+                ) : null}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      <details
+        className="rounded border border-bs-light bg-white p-3"
+        data-testid="stats-raw-details"
+      >
+        <summary className="cursor-pointer text-sm font-semibold text-bs-body">
+          生データテーブル（デバッグ用）
+        </summary>
+        <div className="mt-3">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm text-bs-secondary" data-testid="stats-page-count">
+              {selectedStatsId === ""
+                ? "0 件"
+                : `全 ${String(page.totalCount)} 件（${String(pageOffset + 1)}–${String(Math.min(pageOffset + page.rows.length, page.totalCount))} 件目）`}
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded border border-bs-secondary px-2 py-1 text-sm disabled:opacity-50"
+                disabled={pageOffset <= 0}
+                data-testid="stats-page-prev"
+                onClick={() => {
+                  setPageOffset(Math.max(0, pageOffset - pageLimit));
+                }}
+              >
+                前へ
+              </button>
+              <button
+                type="button"
+                className="rounded border border-bs-secondary px-2 py-1 text-sm disabled:opacity-50"
+                disabled={pageOffset >= maxOffset}
+                data-testid="stats-page-next"
+                onClick={() => {
+                  setPageOffset(Math.min(maxOffset, pageOffset + pageLimit));
+                }}
+              >
+                次へ
+              </button>
+            </div>
+          </div>
+          <StatsRawTable page={page} />
+        </div>
+      </details>
+    </section>
+  );
+};
+
+const StatsRawTable: FunctionComponent<{ page: StatsPageResult }> = ({ page }) => {
+  if (page.rows.length === 0) {
+    return (
+      <p className="text-sm text-bs-secondary" data-testid="stats-raw-empty">
+        生データはありません
+      </p>
+    );
+  }
+
+  let showPacketsReceived = false;
+  let showPacketsSent = false;
+  let showBytesReceived = false;
+  let showBytesSent = false;
+  let showRtt = false;
+  let showKind = false;
+  for (const row of page.rows) {
+    if (row.packets_received !== null) {
+      showPacketsReceived = true;
+    }
+    if (row.packets_sent !== null) {
+      showPacketsSent = true;
+    }
+    if (row.bytes_received !== null) {
+      showBytesReceived = true;
+    }
+    if (row.bytes_sent !== null) {
+      showBytesSent = true;
+    }
+    if (row.round_trip_time !== null) {
+      showRtt = true;
+    }
+    if (row.kind !== null && row.kind !== "") {
+      showKind = true;
+    }
+  }
+
+  return (
+    <div
+      className="max-h-80 overflow-auto rounded border border-bs-light"
+      data-testid="stats-raw-table"
+    >
+      <table className="w-full border-collapse text-left text-xs">
+        <thead className="sticky top-0 bg-bs-light">
+          <tr className="border-b border-bs-secondary">
+            <th className="px-2 py-1.5 font-semibold">時刻 (JST)</th>
+            <th className="px-2 py-1.5 font-semibold">stats_type</th>
+            {showKind ? <th className="px-2 py-1.5 font-semibold">kind</th> : null}
+            {showPacketsReceived ? (
+              <th className="px-2 py-1.5 text-right font-semibold">pkt recv</th>
+            ) : null}
+            {showPacketsSent ? (
+              <th className="px-2 py-1.5 text-right font-semibold">pkt sent</th>
+            ) : null}
+            {showBytesReceived ? (
+              <th className="px-2 py-1.5 text-right font-semibold">bytes recv</th>
+            ) : null}
+            {showBytesSent ? (
+              <th className="px-2 py-1.5 text-right font-semibold">bytes sent</th>
+            ) : null}
+            {showRtt ? <th className="px-2 py-1.5 text-right font-semibold">RTT</th> : null}
+          </tr>
+        </thead>
+        <tbody>
+          {page.rows.map((row, index) => {
+            const rowClass =
+              index % 2 === 0
+                ? "border-b border-bs-light bg-white"
+                : "border-b border-bs-light bg-[#f8f9fa]";
+            return (
+              <tr key={row.id} className={rowClass}>
+                <td className="px-2 py-1 font-mono tabular-nums">
+                  {formatChartUnixSecJst(row.timestamp_ms / 1000, true)}
+                </td>
+                <td className="px-2 py-1">{displayOrDash(row.stats_type)}</td>
+                {showKind ? <td className="px-2 py-1">{displayOrDash(row.kind)}</td> : null}
+                {showPacketsReceived ? (
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {formatTableNumber(row.packets_received)}
+                  </td>
+                ) : null}
+                {showPacketsSent ? (
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {formatTableNumber(row.packets_sent)}
+                  </td>
+                ) : null}
+                {showBytesReceived ? (
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {formatTableBytes(row.bytes_received)}
+                  </td>
+                ) : null}
+                {showBytesSent ? (
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {formatTableBytes(row.bytes_sent)}
+                  </td>
+                ) : null}
+                {showRtt ? (
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {formatTableRtt(row.round_trip_time)}
+                  </td>
+                ) : null}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/components/Sessions/chartFormat.ts
+++ b/src/components/Sessions/chartFormat.ts
@@ -1,0 +1,137 @@
+// チャート共通の表示整形
+
+const JST_TIME_ZONE = "Asia/Tokyo";
+
+const jstTimeFormatter = new Intl.DateTimeFormat("ja-JP", {
+  timeZone: JST_TIME_ZONE,
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+const jstDateTimeFormatter = new Intl.DateTimeFormat("ja-JP", {
+  timeZone: JST_TIME_ZONE,
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+const jstDateKeyFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: JST_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+// 経過秒を 0:00 / 1:05 / 1:02:03 形式にする（テーブル等の相対表示用）
+export function formatElapsed(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  if (hours > 0) {
+    return `${String(hours)}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+  }
+  return `${String(minutes)}:${String(secs).padStart(2, "0")}`;
+}
+
+// Unix 秒を JST の時刻文字列にする
+export function formatChartUnixSecJst(unixSec: number, includeDate: boolean): string {
+  const date = new Date(unixSec * 1000);
+  if (includeDate) {
+    return jstDateTimeFormatter.format(date);
+  }
+  return jstTimeFormatter.format(date);
+}
+
+function jstDateKey(unixSec: number): string {
+  return jstDateKeyFormatter.format(new Date(unixSec * 1000));
+}
+
+function shouldIncludeDateInAxis(splits: number[]): boolean {
+  if (splits.length <= 1) {
+    return false;
+  }
+  const firstKey = jstDateKey(splits[0]);
+  for (let index = 1; index < splits.length; index += 1) {
+    if (jstDateKey(splits[index]) !== firstKey) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// uPlot 横軸: Unix 秒 → JST
+export function axisTimeLabelsJst(_uPlot: unknown, splits: number[]): string[] {
+  const includeDate = shouldIncludeDateInAxis(splits);
+  return splits.map((value) => formatChartUnixSecJst(value, includeDate));
+}
+
+export function formatBitrate(bps: number): string {
+  if (bps >= 1_000_000) {
+    return `${(bps / 1_000_000).toFixed(2)} Mbps`;
+  }
+  if (bps >= 1000) {
+    return `${(bps / 1000).toFixed(1)} kbps`;
+  }
+  return `${Math.round(bps)} bps`;
+}
+
+export function formatRttMs(ms: number): string {
+  if (ms >= 100) {
+    return `${Math.round(ms)} ms`;
+  }
+  return `${ms.toFixed(1)} ms`;
+}
+
+export function formatByteCount(bytes: number): string {
+  if (bytes >= 1_000_000_000) {
+    return `${(bytes / 1_000_000_000).toFixed(2)} GB`;
+  }
+  if (bytes >= 1_000_000) {
+    return `${(bytes / 1_000_000).toFixed(2)} MB`;
+  }
+  if (bytes >= 1000) {
+    return `${(bytes / 1000).toFixed(1)} KB`;
+  }
+  return `${Math.round(bytes)} B`;
+}
+
+export function formatCount(value: number): string {
+  return Math.round(value).toLocaleString("ja-JP");
+}
+
+export function axisCompactNumberLabels(_uPlot: unknown, splits: number[]): string[] {
+  return splits.map((value) => {
+    const abs = Math.abs(value);
+    if (abs >= 1_000_000_000) {
+      return `${(value / 1_000_000_000).toFixed(1)}G`;
+    }
+    if (abs >= 1_000_000) {
+      return `${(value / 1_000_000).toFixed(1)}M`;
+    }
+    if (abs >= 1000) {
+      return `${(value / 1000).toFixed(0)}k`;
+    }
+    return String(Math.round(value));
+  });
+}
+
+export const CHART_HEIGHT = 220;
+export const AXIS_STROKE = "#868e96";
+export const GRID_STROKE = "#e9ecef";
+
+export const SERIES_COLORS = [
+  "#0d6efd",
+  "#198754",
+  "#fd7e14",
+  "#6f42c1",
+  "#d63384",
+  "#20c997",
+  "#0dcaf0",
+  "#ffc107",
+] as const;

--- a/src/routes/Sessions.tsx
+++ b/src/routes/Sessions.tsx
@@ -5,7 +5,12 @@ import { useLocation } from "preact-iso";
 import { SessionDetail } from "@/components/Sessions/SessionDetail";
 import { SessionFilter } from "@/components/Sessions/SessionFilter";
 import { SessionList } from "@/components/Sessions/SessionList";
-import { getCurrentSessionDbId, listSessions, whenReady } from "@/sessionDatabase";
+import {
+  getCurrentSessionDbId,
+  isSessionDatabaseAvailable,
+  listSessions,
+  whenReady,
+} from "@/sessionDatabase";
 import type { SessionListRow } from "@/sessionDatabase";
 import { buildSessionsPath, parseSessionsSearchParams } from "@/sessionsSearchParams";
 import type { SessionsSearchParams } from "@/sessionsSearchParams";
@@ -56,16 +61,14 @@ const Sessions: FunctionComponent = () => {
   const [sessions, setSessions] = useState<SessionListRow[]>([]);
   const [currentSessionDbId, setCurrentSessionDbId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  const [databaseAvailable, setDatabaseAvailable] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // URL 変更に追従してフィルタ状態を同期し、不正値は正規化する
   useEffect(() => {
+    // preact-iso の url だけを見る（location.search フォールバックは DevTools QS 混入の原因になる）
     const searchIndex = url.indexOf("?");
-    const { search: locationSearch } = globalThis.location;
-    let search = locationSearch;
-    if (searchIndex !== -1) {
-      search = url.slice(searchIndex);
-    }
+    const search = searchIndex === -1 ? "" : url.slice(searchIndex);
     const parsed = parseSessionsSearchParams(search);
     setSearchParams(parsed);
 
@@ -84,6 +87,14 @@ const Sessions: FunctionComponent = () => {
       try {
         await whenReady();
         if (active.cancelled) {
+          return;
+        }
+        const available = isSessionDatabaseAvailable();
+        setDatabaseAvailable(available);
+        if (!available) {
+          setSessions([]);
+          setCurrentSessionDbId(null);
+          setLoading(false);
           return;
         }
         const filter = {
@@ -158,14 +169,21 @@ const Sessions: FunctionComponent = () => {
           <p className="text-bs-secondary" data-testid="session-list-loading">
             読み込み中…
           </p>
-        ) : (
+        ) : null}
+        {!loading && !databaseAvailable ? (
+          <p className="text-bs-secondary" data-testid="session-database-unavailable">
+            セッション永続化が利用できません（OPFS
+            非対応、またはデータベース初期化に失敗しています）
+          </p>
+        ) : null}
+        {!loading && databaseAvailable ? (
           <SessionList
             sessions={sessions}
             currentSessionDbId={currentSessionDbId}
             selectedSessionDbId={searchParams.sessionDbId}
             onSelect={handleSelect}
           />
-        )}
+        ) : null}
       </section>
 
       <section>

--- a/src/sessionDatabase.ts
+++ b/src/sessionDatabase.ts
@@ -6,6 +6,12 @@ import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { setSoraErrorAlertMessage } from "@/app/signals";
 import { computeStatsAggregates, computeStatsTimeseries } from "@/statsQuery";
 import type { StatsAggregates, StatsSourceRow, StatsTimeseriesPoint } from "@/statsQuery";
+import { computeStreamTimeseriesForId, listStatsStreams } from "@/statsStreamQuery";
+import type {
+  StatsStreamSummary,
+  StatsStreamTimeseriesPoint,
+  StreamSourceRow,
+} from "@/statsStreamQuery";
 import type { Json } from "@/types";
 import { selectIdsToDeleteForSampling } from "@/webrtcStatsNormalizer";
 import type { NormalizedWebrtcStat } from "@/webrtcStatsNormalizer";
@@ -70,9 +76,38 @@ export interface StatsTimeseriesOptions {
 export interface StatsPageOptions {
   limit?: number;
   offset?: number;
+  // 指定時は stats_type で絞り込む
+  statsType?: string;
+  // 指定時は stats_id で絞り込む（statsType と併用可）
+  statsId?: string;
+}
+
+export type StatsRawMetric =
+  | "bytes_sent"
+  | "bytes_received"
+  | "packets_sent"
+  | "packets_received"
+  | "round_trip_time";
+
+export interface StatsRawSeriesOptions {
+  metric: StatsRawMetric;
+  statsType: string;
+  // 省略時は当該 type の全 stats_id（描画側で上限あり）
+  statsId?: string;
+}
+
+export interface StatsRawSeriesPoint {
+  timestamp_ms: number;
+  stats_id: string;
+  value: number;
 }
 
 export type { StatsAggregates, StatsTimeseriesPoint } from "@/statsQuery";
+export type {
+  StatsStreamSummary,
+  StatsStreamTimeseriesPoint,
+  StatsStreamType,
+} from "@/statsStreamQuery";
 
 // OPFS 上の DuckDB データベースパス（signaling-url-candidates.json と衝突しない名前）
 const OPFS_DB_PATH = "opfs://sora-devtools-sessions.db";
@@ -219,6 +254,11 @@ export function getCurrentConnectionId(): string | null {
 
 export async function whenReady(): Promise<void> {
   return readyPromise;
+}
+
+// 初期化試行後に DuckDB 接続が利用可能か。whenReady() 後に呼ぶこと
+export function isSessionDatabaseAvailable(): boolean {
+  return duckdbConnection !== null;
 }
 
 function warnUnavailable(action: string): void {
@@ -536,6 +576,8 @@ export async function insertSession(
   role: string,
   metadata: Json | undefined,
 ): Promise<number | null> {
+  // 初期化完了前の Connect で no-op にならないよう、書き込み前に初期化を待つ
+  await whenReady();
   return enqueueWrite(async () => {
     if (duckdbConnection === null) {
       warnUnavailable("insertSession");
@@ -582,6 +624,7 @@ export async function updateSessionIdAndConnectionId(
   sessionId: string,
   connectionId: string,
 ): Promise<void> {
+  await whenReady();
   await enqueueWrite(async () => {
     if (duckdbConnection === null) {
       warnUnavailable("updateSessionIdAndConnectionId");
@@ -615,6 +658,7 @@ export async function insertConnection(
   channelId: string,
   signalingUrl: string,
 ): Promise<boolean> {
+  await whenReady();
   return enqueueWrite(async () => {
     if (duckdbConnection === null) {
       warnUnavailable("insertConnection");
@@ -654,6 +698,7 @@ export async function insertConnection(
 }
 
 export async function updateSessionEndedAt(id: number): Promise<void> {
+  await whenReady();
   await enqueueWrite(async () => {
     if (duckdbConnection === null) {
       warnUnavailable("updateSessionEndedAt");
@@ -687,6 +732,7 @@ export async function updateConnectionEndedAt(connectionId: string): Promise<voi
   if (!connectionId) {
     return;
   }
+  await whenReady();
   await enqueueWrite(async () => {
     if (duckdbConnection === null) {
       warnUnavailable("updateConnectionEndedAt");
@@ -1379,14 +1425,14 @@ export async function queryStatsAggregates(sessionDbId: number): Promise<StatsAg
   });
 }
 
-// 時系列サンプリング。intervalSec は 10 または 60（省略時 10）
+// 時系列サンプリング。intervalSec は 1 / 10 / 60（省略時 1。収集間隔に合わせた 1 秒が既定）
 export async function queryStatsTimeseries(
   sessionDbId: number,
   options: StatsTimeseriesOptions = {},
 ): Promise<StatsTimeseriesPoint[]> {
-  const intervalSec = options.intervalSec ?? 10;
-  if (intervalSec !== 10 && intervalSec !== 60) {
-    throw new Error(`intervalSec must be 10 or 60, got ${String(intervalSec)}`);
+  const intervalSec = options.intervalSec ?? 1;
+  if (intervalSec !== 1 && intervalSec !== 10 && intervalSec !== 60) {
+    throw new Error(`intervalSec must be 1, 10, or 60, got ${String(intervalSec)}`);
   }
   return enqueueWrite(async () => {
     if (duckdbConnection === null) {
@@ -1404,24 +1450,45 @@ export async function queryStatsPage(
 ): Promise<StatsPageResult> {
   const limit = options.limit ?? 50;
   const offset = options.offset ?? 0;
+  const { statsType } = options;
+  const { statsId } = options;
   if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
     throw new Error(`limit must be an integer in 1..200, got ${String(limit)}`);
   }
   if (!Number.isInteger(offset) || offset < 0) {
     throw new Error(`offset must be a non-negative integer, got ${String(offset)}`);
   }
+  if (statsType !== undefined && statsType === "") {
+    throw new Error("statsType must be a non-empty string when provided");
+  }
+  if (statsId !== undefined && statsId === "") {
+    throw new Error("statsId must be a non-empty string when provided");
+  }
   return enqueueWrite(async () => {
     if (duckdbConnection === null) {
       return { rows: [], totalCount: 0 };
     }
+
+    const filters: string[] = ["session_db_id = ?"];
+    const filterParams: Array<number | string> = [sessionDbId];
+    if (statsType !== undefined) {
+      filters.push("stats_type = ?");
+      filterParams.push(statsType);
+    }
+    if (statsId !== undefined) {
+      filters.push("stats_id = ?");
+      filterParams.push(statsId);
+    }
+    const whereClause = filters.join(" AND ");
+
     const countStatement = await duckdbConnection.prepare(`
       SELECT COUNT(*) AS total_count
       FROM webrtc_stats
-      WHERE session_db_id = ?
+      WHERE ${whereClause}
     `);
     let totalCount = 0;
     try {
-      const countTable = await countStatement.query(sessionDbId);
+      const countTable = await countStatement.query(...filterParams);
       const countRecords = arrowTableToRecords(countTable);
       if (countRecords.length > 0) {
         const [first] = countRecords;
@@ -1444,13 +1511,13 @@ export async function queryStatsPage(
         bytes_sent,
         round_trip_time
       FROM webrtc_stats
-      WHERE session_db_id = ?
+      WHERE ${whereClause}
       ORDER BY timestamp_ms ASC, id ASC
       LIMIT ?
       OFFSET ?
     `);
     try {
-      const pageTable = await pageStatement.query(sessionDbId, limit, offset);
+      const pageTable = await pageStatement.query(...filterParams, limit, offset);
       const rows = arrowTableToRecords(pageTable).map(
         (record): StatsPageRow => ({
           id: requireNumber(record.id, "webrtc_stats.id"),
@@ -1469,5 +1536,210 @@ export async function queryStatsPage(
     } finally {
       await pageStatement.close();
     }
+  });
+}
+
+const RAW_METRIC_COLUMNS: Record<StatsRawMetric, string> = {
+  bytes_sent: "bytes_sent",
+  bytes_received: "bytes_received",
+  packets_sent: "packets_sent",
+  packets_received: "packets_received",
+  round_trip_time: "round_trip_time",
+};
+
+// 生データグラフ用: 指定 type / metric の時系列（最大 20000 点）
+export async function queryStatsRawSeries(
+  sessionDbId: number,
+  options: StatsRawSeriesOptions,
+): Promise<StatsRawSeriesPoint[]> {
+  const column = RAW_METRIC_COLUMNS[options.metric];
+  if (options.statsType === "") {
+    throw new Error("statsType must be a non-empty string");
+  }
+  if (options.statsId !== undefined && options.statsId === "") {
+    throw new Error("statsId must be a non-empty string when provided");
+  }
+  const hasStatsId = options.statsId !== undefined;
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return [];
+    }
+    // カラム名はホワイトリスト済み。プレースホルダには入れられない
+    const sql = hasStatsId
+      ? `
+      SELECT timestamp_ms, stats_id, ${column} AS value
+      FROM webrtc_stats
+      WHERE session_db_id = ?
+        AND stats_type = ?
+        AND stats_id = ?
+        AND ${column} IS NOT NULL
+      ORDER BY timestamp_ms ASC, id ASC
+      LIMIT 20000
+    `
+      : `
+      SELECT timestamp_ms, stats_id, ${column} AS value
+      FROM webrtc_stats
+      WHERE session_db_id = ?
+        AND stats_type = ?
+        AND ${column} IS NOT NULL
+      ORDER BY timestamp_ms ASC, id ASC
+      LIMIT 20000
+    `;
+    const statement = await duckdbConnection.prepare(sql);
+    try {
+      const table = hasStatsId
+        ? await statement.query(sessionDbId, options.statsType, options.statsId)
+        : await statement.query(sessionDbId, options.statsType);
+      const points: StatsRawSeriesPoint[] = [];
+      for (const record of arrowTableToRecords(table)) {
+        const statsId = toNullableString(record.stats_id);
+        const value = toFiniteNumber(record.value);
+        if (statsId === null || value === null) {
+          continue;
+        }
+        points.push({
+          timestamp_ms: requireNumber(record.timestamp_ms, "webrtc_stats.timestamp_ms"),
+          stats_id: statsId,
+          value,
+        });
+      }
+      return points;
+    } finally {
+      await statement.close();
+    }
+  });
+}
+
+// セッション内の stats_type 一覧（生データ絞り込み用）
+export async function listStatsTypes(sessionDbId: number): Promise<string[]> {
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return [];
+    }
+    const statement = await duckdbConnection.prepare(`
+      SELECT DISTINCT stats_type
+      FROM webrtc_stats
+      WHERE session_db_id = ?
+        AND stats_type IS NOT NULL
+      ORDER BY stats_type ASC
+    `);
+    try {
+      const table = await statement.query(sessionDbId);
+      const types: string[] = [];
+      for (const record of arrowTableToRecords(table)) {
+        const statsType = toNullableString(record.stats_type);
+        if (statsType !== null) {
+          types.push(statsType);
+        }
+      }
+      return types;
+    } finally {
+      await statement.close();
+    }
+  });
+}
+
+// 指定 stats_type 内の stats_id 一覧
+export async function listStatsIds(sessionDbId: number, statsType: string): Promise<string[]> {
+  if (statsType === "") {
+    throw new Error("statsType must be a non-empty string");
+  }
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return [];
+    }
+    const statement = await duckdbConnection.prepare(`
+      SELECT DISTINCT stats_id
+      FROM webrtc_stats
+      WHERE session_db_id = ?
+        AND stats_type = ?
+        AND stats_id IS NOT NULL
+      ORDER BY stats_id ASC
+    `);
+    try {
+      const table = await statement.query(sessionDbId, statsType);
+      const ids: string[] = [];
+      for (const record of arrowTableToRecords(table)) {
+        const statsId = toNullableString(record.stats_id);
+        if (statsId !== null) {
+          ids.push(statsId);
+        }
+      }
+      return ids;
+    } finally {
+      await statement.close();
+    }
+  });
+}
+
+async function loadStreamSourceRowsUnlocked(sessionDbId: number): Promise<StreamSourceRow[]> {
+  if (duckdbConnection === null) {
+    return [];
+  }
+  const statement = await duckdbConnection.prepare(`
+    SELECT
+      id,
+      timestamp_ms,
+      stats_type,
+      stats_id,
+      kind,
+      packets_received,
+      packets_sent,
+      bytes_received,
+      bytes_sent,
+      round_trip_time
+    FROM webrtc_stats
+    WHERE session_db_id = ?
+      AND stats_type IN ('outbound-rtp', 'inbound-rtp', 'candidate-pair')
+    ORDER BY timestamp_ms ASC, id ASC
+  `);
+  try {
+    const table = await statement.query(sessionDbId);
+    return arrowTableToRecords(table).map((record) => {
+      const statsType = toNullableString(record.stats_type);
+      const statsId = toNullableString(record.stats_id);
+      return {
+        id: requireNumber(record.id, "webrtc_stats.id"),
+        timestamp_ms: requireNumber(record.timestamp_ms, "webrtc_stats.timestamp_ms"),
+        stats_type: statsType ?? "",
+        stats_id: statsId ?? "",
+        kind: toNullableString(record.kind),
+        packets_received: toFiniteNumber(record.packets_received),
+        packets_sent: toFiniteNumber(record.packets_sent),
+        bytes_received: toFiniteNumber(record.bytes_received),
+        bytes_sent: toFiniteNumber(record.bytes_sent),
+        round_trip_time: toFiniteNumber(record.round_trip_time),
+      };
+    });
+  } finally {
+    await statement.close();
+  }
+}
+
+// ストリーム一覧（outbound / inbound / candidate-pair）
+export async function queryStatsStreams(sessionDbId: number): Promise<StatsStreamSummary[]> {
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return [];
+    }
+    const rows = await loadStreamSourceRowsUnlocked(sessionDbId);
+    return listStatsStreams(rows);
+  });
+}
+
+// 1 ストリームの差分時系列
+export async function queryStatsStreamTimeseries(
+  sessionDbId: number,
+  statsId: string,
+): Promise<StatsStreamTimeseriesPoint[]> {
+  if (statsId === "") {
+    throw new Error("statsId must be a non-empty string");
+  }
+  return enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      return [];
+    }
+    const rows = await loadStreamSourceRowsUnlocked(sessionDbId);
+    return computeStreamTimeseriesForId(rows, statsId);
   });
 }

--- a/src/statsQuery.test.ts
+++ b/src/statsQuery.test.ts
@@ -167,6 +167,42 @@ test("computeStatsTimeseries は intervalSec でバケット化する", () => {
   assert.isDefined(second);
 });
 
+// 1 秒バケット: getStats 収集間隔に合わせた既定
+test("computeStatsTimeseries は 1 秒間隔でバケット化する", () => {
+  const rows: StatsSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 0,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 0,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 1000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 1000,
+    }),
+    row({
+      id: 3,
+      timestamp_ms: 2000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      bytes_sent: 2500,
+    }),
+  ];
+  const points = computeStatsTimeseries(rows, 1);
+  assert.equal(points.length, 3);
+  assert.equal(points[0]?.timestamp_ms, 0);
+  assert.equal(points[0]?.bitrate_send_bps, null);
+  assert.equal(points[1]?.timestamp_ms, 1000);
+  assert.equal(points[1]?.bitrate_send_bps, 8000);
+  assert.equal(points[2]?.timestamp_ms, 2000);
+  // (2500-1000)*8*1000/1000 = 12000
+  assert.equal(points[2]?.bitrate_send_bps, 12_000);
+});
+
 // 同一バケット内の複数サンプルは stats_id 単位 last のみ使い、全サンプル合算しない
 test("computeStatsTimeseries はバケット内で stats_id 単位の last を使う", () => {
   const rows: StatsSourceRow[] = [

--- a/src/statsQuery.ts
+++ b/src/statsQuery.ts
@@ -315,7 +315,7 @@ function foldBucketSamples(samples: StreamSample[]): {
   };
 }
 
-// 時系列サンプリング。intervalSec は呼び出し側で 10 または 60 に限定する
+// 時系列サンプリング。intervalSec は呼び出し側で 1 / 10 / 60 に限定する
 export function computeStatsTimeseries(
   rows: StatsSourceRow[],
   intervalSec: number,

--- a/src/statsRawSeries.test.ts
+++ b/src/statsRawSeries.test.ts
@@ -1,0 +1,53 @@
+import { assert, test } from "vite-plus/test";
+
+import { alignRawSeriesPoints, maxRawSeriesCount } from "./statsRawSeries.ts";
+import type { RawSeriesPoint } from "./statsRawSeries.ts";
+
+test("alignRawSeriesPoints は空配列で空を返す", () => {
+  assert.deepEqual(alignRawSeriesPoints([]), { timestampsSec: [], series: [] });
+});
+
+test("alignRawSeriesPoints は単一系列を Unix 秒に整列する", () => {
+  const points: RawSeriesPoint[] = [
+    { timestamp_ms: 1000, stats_id: "out-a", value: 10 },
+    { timestamp_ms: 2000, stats_id: "out-a", value: 20 },
+  ];
+  const aligned = alignRawSeriesPoints(points);
+  assert.deepEqual(aligned.timestampsSec, [1, 2]);
+  assert.equal(aligned.series.length, 1);
+  assert.equal(aligned.series[0]?.statsId, "out-a");
+  assert.deepEqual(aligned.series[0]?.values, [10, 20]);
+});
+
+test("alignRawSeriesPoints は複数系列の欠測を null にする", () => {
+  const points: RawSeriesPoint[] = [
+    { timestamp_ms: 0, stats_id: "a", value: 1 },
+    { timestamp_ms: 1000, stats_id: "b", value: 2 },
+    { timestamp_ms: 1000, stats_id: "a", value: 3 },
+  ];
+  const aligned = alignRawSeriesPoints(points);
+  assert.deepEqual(aligned.timestampsSec, [0, 1]);
+  const seriesA = aligned.series.find((entry) => entry.statsId === "a");
+  const seriesB = aligned.series.find((entry) => entry.statsId === "b");
+  assert.deepEqual(seriesA?.values, [1, 3]);
+  assert.deepEqual(seriesB?.values, [null, 2]);
+});
+
+test("alignRawSeriesPoints は系列数を上限で切る", () => {
+  const points: RawSeriesPoint[] = [];
+  const limit = maxRawSeriesCount();
+  for (let index = 0; index < limit + 2; index += 1) {
+    // 件数が多い系列を優先するため、index が小さいほど多くする
+    const count = limit + 2 - index;
+    for (let sample = 0; sample < count; sample += 1) {
+      points.push({
+        timestamp_ms: sample * 1000,
+        stats_id: `id-${String(index)}`,
+        value: sample,
+      });
+    }
+  }
+  const aligned = alignRawSeriesPoints(points);
+  assert.equal(aligned.series.length, limit);
+  assert.equal(aligned.series[0]?.statsId, "id-0");
+});

--- a/src/statsRawSeries.ts
+++ b/src/statsRawSeries.ts
@@ -1,0 +1,76 @@
+// 生データグラフ用の時系列整形（純粋関数）
+
+export interface RawSeriesPoint {
+  timestamp_ms: number;
+  stats_id: string;
+  value: number;
+}
+
+export interface AlignedRawSeries {
+  // Unix 秒（uPlot time スケール用）
+  timestampsSec: number[];
+  // stats_id ごとの系列（欠測は null）
+  series: Array<{ statsId: string; values: Array<number | null> }>;
+}
+
+const MAX_SERIES = 8;
+
+// 複数 stats_id を uPlot 向けに時刻整列する（系列数は上限あり）
+export function alignRawSeriesPoints(points: RawSeriesPoint[]): AlignedRawSeries {
+  if (points.length === 0) {
+    return { timestampsSec: [], series: [] };
+  }
+
+  const counts = new Map<string, number>();
+  for (const point of points) {
+    counts.set(point.stats_id, (counts.get(point.stats_id) ?? 0) + 1);
+  }
+  const rankedIds = [...counts.entries()]
+    .toSorted((left, right) => {
+      if (right[1] !== left[1]) {
+        return right[1] - left[1];
+      }
+      return left[0].localeCompare(right[0]);
+    })
+    .slice(0, MAX_SERIES)
+    .map(([statsId]) => statsId);
+  const allowed = new Set(rankedIds);
+
+  const timestamps: number[] = [];
+  const seenTs = new Set<number>();
+  const byId = new Map<string, Map<number, number>>();
+  for (const statsId of rankedIds) {
+    byId.set(statsId, new Map());
+  }
+
+  for (const point of points) {
+    if (!allowed.has(point.stats_id)) {
+      continue;
+    }
+    if (!seenTs.has(point.timestamp_ms)) {
+      seenTs.add(point.timestamp_ms);
+      timestamps.push(point.timestamp_ms);
+    }
+    byId.get(point.stats_id)?.set(point.timestamp_ms, point.value);
+  }
+  timestamps.sort((a, b) => a - b);
+
+  const timestampsSec = timestamps.map((timestampMs) => timestampMs / 1000);
+  const series = rankedIds.map((statsId) => {
+    const valuesByTs = byId.get(statsId) ?? new Map<number, number>();
+    const values = timestamps.map((timestampMs) => {
+      const value = valuesByTs.get(timestampMs);
+      if (value === undefined) {
+        return null;
+      }
+      return value;
+    });
+    return { statsId, values };
+  });
+
+  return { timestampsSec, series };
+}
+
+export function maxRawSeriesCount(): number {
+  return MAX_SERIES;
+}

--- a/src/statsStreamQuery.test.ts
+++ b/src/statsStreamQuery.test.ts
@@ -1,0 +1,115 @@
+import { assert, test } from "vite-plus/test";
+
+import {
+  computeStreamTimeseries,
+  computeStreamTimeseriesForId,
+  listStatsStreams,
+} from "./statsStreamQuery.ts";
+import type { StreamSourceRow } from "./statsStreamQuery.ts";
+
+function row(
+  partial: Partial<StreamSourceRow> &
+    Pick<StreamSourceRow, "id" | "timestamp_ms" | "stats_type" | "stats_id">,
+): StreamSourceRow {
+  return {
+    kind: null,
+    packets_received: null,
+    packets_sent: null,
+    bytes_received: null,
+    bytes_sent: null,
+    round_trip_time: null,
+    ...partial,
+  };
+}
+
+test("listStatsStreams は outbound/inbound/candidate-pair だけを返す", () => {
+  const rows: StreamSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 0,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      kind: "video",
+      bytes_sent: 0,
+      packets_sent: 0,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 1000,
+      stats_type: "outbound-rtp",
+      stats_id: "out-a",
+      kind: "video",
+      bytes_sent: 1000,
+      packets_sent: 10,
+    }),
+    row({
+      id: 3,
+      timestamp_ms: 1000,
+      stats_type: "codec",
+      stats_id: "codec-1",
+    }),
+  ];
+  const streams = listStatsStreams(rows);
+  assert.equal(streams.length, 1);
+  assert.equal(streams[0]?.stats_id, "out-a");
+  assert.equal(streams[0]?.kind, "video");
+  assert.equal(streams[0]?.sample_count, 2);
+  assert.equal(streams[0]?.last_bitrate_bps, 8000);
+  assert.equal(streams[0]?.last_packet_rate_pps, 10);
+});
+
+test("computeStreamTimeseries は差分ビットレートとパケットレートを出す", () => {
+  const rows: StreamSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 0,
+      stats_type: "inbound-rtp",
+      stats_id: "in-a",
+      bytes_received: 0,
+      packets_received: 0,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 1000,
+      stats_type: "inbound-rtp",
+      stats_id: "in-a",
+      bytes_received: 500,
+      packets_received: 5,
+    }),
+  ];
+  const points = computeStreamTimeseries(rows);
+  assert.equal(points.length, 2);
+  assert.equal(points[0]?.bitrate_bps, null);
+  assert.equal(points[1]?.bitrate_bps, 4000);
+  assert.equal(points[1]?.packet_rate_pps, 5);
+});
+
+test("computeStreamTimeseriesForId は指定 id だけを対象にする", () => {
+  const rows: StreamSourceRow[] = [
+    row({
+      id: 1,
+      timestamp_ms: 0,
+      stats_type: "candidate-pair",
+      stats_id: "pair-a",
+      round_trip_time: 0.02,
+    }),
+    row({
+      id: 2,
+      timestamp_ms: 1000,
+      stats_type: "candidate-pair",
+      stats_id: "pair-b",
+      round_trip_time: 0.05,
+    }),
+    row({
+      id: 3,
+      timestamp_ms: 2000,
+      stats_type: "candidate-pair",
+      stats_id: "pair-a",
+      round_trip_time: 0.03,
+    }),
+  ];
+  const points = computeStreamTimeseriesForId(rows, "pair-a");
+  assert.equal(points.length, 2);
+  assert.equal(points[0]?.round_trip_time, 0.02);
+  assert.equal(points[1]?.round_trip_time, 0.03);
+});

--- a/src/statsStreamQuery.ts
+++ b/src/statsStreamQuery.ts
@@ -1,0 +1,193 @@
+// stats_id 単位のストリーム要約・差分時系列（試行用の純粋関数）
+
+export interface StreamSourceRow {
+  id: number;
+  timestamp_ms: number;
+  stats_type: string;
+  stats_id: string;
+  kind: string | null;
+  packets_received: number | null;
+  packets_sent: number | null;
+  bytes_received: number | null;
+  bytes_sent: number | null;
+  round_trip_time: number | null;
+}
+
+export type StatsStreamType = "outbound-rtp" | "inbound-rtp" | "candidate-pair";
+
+export interface StatsStreamSummary {
+  stats_type: StatsStreamType;
+  stats_id: string;
+  kind: string | null;
+  sample_count: number;
+  // 直近付近の要約（差分から算出。無ければ null）
+  last_bitrate_bps: number | null;
+  last_packet_rate_pps: number | null;
+  last_round_trip_time: number | null;
+}
+
+export interface StatsStreamTimeseriesPoint {
+  timestamp_ms: number;
+  bitrate_bps: number | null;
+  packet_rate_pps: number | null;
+  round_trip_time: number | null;
+}
+
+const STREAM_TYPES = new Set<string>(["outbound-rtp", "inbound-rtp", "candidate-pair"]);
+
+function compareByTimeThenId(
+  a: { timestamp_ms: number; id: number },
+  b: { timestamp_ms: number; id: number },
+): number {
+  if (a.timestamp_ms !== b.timestamp_ms) {
+    return a.timestamp_ms - b.timestamp_ms;
+  }
+  return a.id - b.id;
+}
+
+function isStreamType(value: string): value is StatsStreamType {
+  return STREAM_TYPES.has(value);
+}
+
+function positiveBitrateBps(
+  prevBytes: number | null,
+  currBytes: number | null,
+  deltaMs: number,
+): number | null {
+  if (prevBytes === null || currBytes === null || deltaMs <= 0) {
+    return null;
+  }
+  const deltaBytes = currBytes - prevBytes;
+  if (deltaBytes <= 0) {
+    return null;
+  }
+  return (deltaBytes * 8 * 1000) / deltaMs;
+}
+
+function positivePacketRatePps(
+  prevPackets: number | null,
+  currPackets: number | null,
+  deltaMs: number,
+): number | null {
+  if (prevPackets === null || currPackets === null || deltaMs <= 0) {
+    return null;
+  }
+  const deltaPackets = currPackets - prevPackets;
+  if (deltaPackets <= 0) {
+    return null;
+  }
+  return (deltaPackets * 1000) / deltaMs;
+}
+
+function groupByStatsId(rows: StreamSourceRow[]): Map<string, StreamSourceRow[]> {
+  const byStatsId = new Map<string, StreamSourceRow[]>();
+  for (const row of rows) {
+    if (!isStreamType(row.stats_type) || row.stats_id === "") {
+      continue;
+    }
+    const list = byStatsId.get(row.stats_id);
+    if (list === undefined) {
+      byStatsId.set(row.stats_id, [row]);
+    } else {
+      list.push(row);
+    }
+  }
+  return byStatsId;
+}
+
+function lastNonNull(values: Array<number | null>): number | null {
+  for (let index = values.length - 1; index >= 0; index -= 1) {
+    const value = values[index];
+    if (value !== null) {
+      return value;
+    }
+  }
+  return null;
+}
+
+// 対象ストリーム種別の一覧要約を作る
+export function listStatsStreams(rows: StreamSourceRow[]): StatsStreamSummary[] {
+  const byStatsId = groupByStatsId(rows);
+  const summaries: StatsStreamSummary[] = [];
+
+  for (const [statsId, list] of byStatsId.entries()) {
+    if (list.length === 0) {
+      continue;
+    }
+    const sorted = [...list].toSorted(compareByTimeThenId);
+    const [first] = sorted;
+    if (!isStreamType(first.stats_type)) {
+      continue;
+    }
+    const points = computeStreamTimeseries(sorted);
+    let kind: string | null = null;
+    for (const row of sorted) {
+      const { kind: rowKind } = row;
+      if (rowKind !== null && rowKind !== "") {
+        kind = rowKind;
+      }
+    }
+    summaries.push({
+      stats_type: first.stats_type,
+      stats_id: statsId,
+      kind,
+      sample_count: sorted.length,
+      last_bitrate_bps: lastNonNull(points.map((point) => point.bitrate_bps)),
+      last_packet_rate_pps: lastNonNull(points.map((point) => point.packet_rate_pps)),
+      last_round_trip_time: lastNonNull(points.map((point) => point.round_trip_time)),
+    });
+  }
+
+  return summaries.toSorted((left, right) => {
+    if (left.stats_type !== right.stats_type) {
+      return left.stats_type.localeCompare(right.stats_type);
+    }
+    return left.stats_id.localeCompare(right.stats_id);
+  });
+}
+
+// 1 ストリーム分の差分時系列（先頭サンプルは差分不能なので bitrate/packet は null）
+export function computeStreamTimeseries(rows: StreamSourceRow[]): StatsStreamTimeseriesPoint[] {
+  if (rows.length === 0) {
+    return [];
+  }
+  const sorted = [...rows].toSorted(compareByTimeThenId);
+  const points: StatsStreamTimeseriesPoint[] = [];
+
+  for (let index = 0; index < sorted.length; index += 1) {
+    const curr = sorted[index];
+    let bitrate: number | null = null;
+    let packetRate: number | null = null;
+    if (index > 0) {
+      const prev = sorted[index - 1];
+      const deltaMs = curr.timestamp_ms - prev.timestamp_ms;
+      if (curr.stats_type === "outbound-rtp") {
+        bitrate = positiveBitrateBps(prev.bytes_sent, curr.bytes_sent, deltaMs);
+        packetRate = positivePacketRatePps(prev.packets_sent, curr.packets_sent, deltaMs);
+      } else if (curr.stats_type === "inbound-rtp") {
+        bitrate = positiveBitrateBps(prev.bytes_received, curr.bytes_received, deltaMs);
+        packetRate = positivePacketRatePps(prev.packets_received, curr.packets_received, deltaMs);
+      }
+    }
+    let rtt: number | null = null;
+    if (curr.stats_type === "candidate-pair") {
+      rtt = curr.round_trip_time;
+    }
+    points.push({
+      timestamp_ms: curr.timestamp_ms,
+      bitrate_bps: bitrate,
+      packet_rate_pps: packetRate,
+      round_trip_time: rtt,
+    });
+  }
+  return points;
+}
+
+// 指定 stats_id の行だけに絞って時系列化する
+export function computeStreamTimeseriesForId(
+  rows: StreamSourceRow[],
+  statsId: string,
+): StatsStreamTimeseriesPoint[] {
+  const filtered = rows.filter((row) => row.stats_id === statsId);
+  return computeStreamTimeseries(filtered);
+}

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -17,7 +17,9 @@ test("ルーティング: / /devtools/ /devtools で DevTools が表示される
   await page.locator(CONNECT_BUTTON_SELECTOR).waitFor({ timeout: 5000 });
 });
 
-test("ルーティング: Sessions ボタンで /sessions に遷移する", async ({ page }) => {
+test("ルーティング: Sessions ボタンで /sessions に遷移し、再クリックで / に戻る", async ({
+  page,
+}) => {
   await page.goto(`${BASE_URL}/devtools/`);
 
   await page.getByRole("button", { name: "Sessions" }).click();
@@ -27,6 +29,10 @@ test("ルーティング: Sessions ボタンで /sessions に遷移する", asyn
   if (pathname !== "/sessions") {
     throw new Error(`expected pathname "/sessions", got "${pathname}"`);
   }
+
+  await page.getByRole("button", { name: "Sessions" }).click();
+  await page.waitForURL((url) => url.pathname === "/", { timeout: 5000 });
+  await page.locator(CONNECT_BUTTON_SELECTOR).waitFor({ timeout: 5000 });
 });
 
 test("ルーティング: /sessions 直アクセスで Sessions ページが表示される", async ({ page }) => {

--- a/tests/session-persist-before-ready.test.ts
+++ b/tests/session-persist-before-ready.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+import { requireSoraConnectionEnv } from "./helpers/env.ts";
+import {
+  awaitSessionDatabaseReady,
+  cleanupSessionDatabase,
+  waitForEndedAt,
+} from "./helpers/sessionDatabase.ts";
+import { DevtoolsPage } from "./pages/DevtoolsPage.ts";
+
+// OPFS 上の DB はオリジン共有のため直列実行する
+test.describe.configure({ mode: "serial" });
+
+const BASE_URL = "http://localhost:3333";
+
+test.describe("session persist before database ready", () => {
+  test.beforeEach(async ({ page }) => {
+    await cleanupSessionDatabase(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupSessionDatabase(page);
+  });
+
+  // DuckDB 初期化完了を待たずに Connect しても sessions が残ることを確認する
+  test("初期化完了前の接続でも /sessions 一覧に残る", async ({ page }) => {
+    const env = requireSoraConnectionEnv();
+    const channelId = `${env.channelIdPrefix}session-persist-before-ready`;
+    const devtools = new DevtoolsPage(page);
+
+    await devtools.navigate({
+      role: "sendrecv",
+      channelId,
+      signalingUrlCandidates: [env.signalingUrl],
+      accessToken: env.accessToken,
+      videoCodecType: "VP9",
+    });
+
+    // whenReady を待たずにすぐ接続する（初期化との競合を再現する）
+    await page.locator('button[name="connect"]').waitFor({ timeout: 10_000 });
+    await devtools.connect();
+    await devtools.waitForConnection();
+    const connectionId = await devtools.getConnectionId();
+    expect(connectionId).toBeTruthy();
+    if (!connectionId) {
+      return;
+    }
+
+    await page.waitForTimeout(1000);
+    await devtools.disconnect();
+    await waitForEndedAt(page, { connectionId });
+    await awaitSessionDatabaseReady(page);
+
+    await page.goto(`${BASE_URL}/sessions`);
+    await page.getByTestId("session-list").waitFor({ timeout: 10_000 });
+    await expect(page.getByTestId("session-list")).toContainText(channelId);
+  });
+});

--- a/tests/sessions-page.test.ts
+++ b/tests/sessions-page.test.ts
@@ -101,10 +101,10 @@ test.describe("sessions page UI", () => {
     // 集計または時系列に実データが見えること（厳密な数値一致は求めない）
     await page.getByTestId("stats-aggregates").waitFor({ timeout: 10_000 });
     await page.getByTestId("stats-timeseries").waitFor({ timeout: 10_000 });
-    const rawTable = page.getByTestId("stats-raw-table");
+    const rawPanel = page.getByTestId("stats-raw-panel");
     const aggregatesText = await page.getByTestId("stats-aggregates").textContent();
     const hasAggregateValue = aggregatesText !== null && /\d/u.test(aggregatesText);
-    const hasRawRows = await rawTable.isVisible().catch(() => false);
-    expect(hasAggregateValue || hasRawRows).toBe(true);
+    const hasRawPanel = await rawPanel.isVisible().catch(() => false);
+    expect(hasAggregateValue || hasRawPanel).toBe(true);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
             "noise-suppression": ["@shiguredo/noise-suppression"],
             "virtual-background": ["@shiguredo/virtual-background"],
             "sora-js-sdk": ["sora-js-sdk"],
+            uplot: ["uplot"],
           };
           const matched = Object.entries(chunks).find(([, modules]) =>
             modules.some((mod) => moduleId.includes(`node_modules/${mod}`)),


### PR DESCRIPTION
## 変更内容

- /sessions ページに過去セッション一覧・詳細・フィルタ UI を実装する
- uPlot を導入して Sessions の時系列チャートを 1 秒単位で描画する
- Sessions の生データを stats_type 別にグラフ表示できるようにする
- Sessions の生データ表示をストリーム選択 + 差分メトリクスに試行変更する
- WebRTC stats を DuckDB-Wasm + OPFS に永続化する
- DuckDB-Wasm + OPFS でセッション・接続メタデータを永続化する
- preact-iso を導入して /sessions ページへのルーティング基盤を追加する
- Sessions ボタンをトグルにして /sessions と DevTools を往復できるようにする
- DuckDB 初期化完了前の接続でセッションが永続化されない競合を修正する

## 動作確認

- vp check: pass
- vp test run: pass (256 tests)
- vp build: pass
- playwright test --project=chromium: pass (17 tests)