### PR TITLE
0072 Sessions 機能をビルド時に無効化できるようにする

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,7 @@
 VITE_SORA_SIGNALING_URL=ws://localhost:5000/signaling
 VITE_VIRTUAL_BACKGROUND_ASSETS_PATH=https://cdn.jsdelivr.net/npm/@shiguredo/virtual-background@2023.2.0/dist
+# Sessions 機能（DuckDB-Wasm によるセッション永続化）を有効にする場合は true を指定してください
+VITE_ENABLE_SESSIONS=false
 
 # テストに利用する Sora の Signaling URL を指定してください
 E2E_TEST_SORA_SIGNALING_URL=ws://127.0.0.1:5000/signaling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,34 @@ jobs:
           node-version-file: ".node-version"
           run-install: true
       - run: vp check
+      # CI では Sessions 機能を有効化してビルド・テストする
       - run: vp build
+        env:
+          VITE_ENABLE_SESSIONS: "true"
       - run: vp test run
+        env:
+          VITE_ENABLE_SESSIONS: "true"
+      # Sessions 無効ビルドが成功し、DuckDB-Wasm / Apache Arrow / uPlot /
+      # Sessions ページ関連のアセットが含まれないことを検証する
+      - run: rm -rf dist && vp build
+        env:
+          VITE_ENABLE_SESSIONS: "false"
+      - run: |
+          if [ ! -d dist/assets ]; then
+            echo "dist/assets is missing"
+            exit 1
+          fi
+          forbidden=$(ls dist/assets | grep -Ei 'duckdb|apache-arrow|uplot|Sessions|sessionDatabase' || true)
+          if [ -n "$forbidden" ]; then
+            echo "Sessions-disabled build must not contain Sessions-related assets:"
+            echo "$forbidden"
+            exit 1
+          fi
+      # 無効モードでも unit test を実行し、ラッパーの no-op 契約を検証する
+      # （有効モードでは test.skipIf で該当テストが skip されるため）
+      - run: vp test run
+        env:
+          VITE_ENABLE_SESSIONS: "false"
 
   slack_notify:
     needs:

--- a/.github/workflows/deploy-r2.yml
+++ b/.github/workflows/deploy-r2.yml
@@ -20,7 +20,10 @@ jobs:
         with:
           node-version: "26"
       - run: vp install --frozen-lockfile
+      # デプロイするビルドでは Sessions 機能を有効化する
       - run: vp build
+        env:
+          VITE_ENABLE_SESSIONS: "true"
       # R2 へのアップロード
       - name: Configure AWS CLI for R2
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -29,7 +29,10 @@ jobs:
           node-version: "26"
           cache: true
       - run: vp install
+      # E2E では Sessions 機能を有効化して検証する
       - run: vp build
+        env:
+          VITE_ENABLE_SESSIONS: "true"
       - run: vp exec playwright install ${{ matrix.browser }} --with-deps
       - run: vp exec playwright test --project=${{ matrix.browser }}
         env:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [CHANGE] Sessions 機能をビルド時にデフォルト無効化し、環境変数で有効化できるようにする
+  - @voluntas
 - [ADD] /sessions ページに過去セッション一覧・詳細・フィルタ UI を実装する
   - @voluntas
 - [ADD] uPlot を導入して Sessions の時系列チャートを 1 秒単位で描画する

--- a/issues/closed/0072-change-build-time-disable-sessions.md
+++ b/issues/closed/0072-change-build-time-disable-sessions.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-07-11
-- Completed: YYYY-MM-DD
+- Completed: 2026-07-12
 - Model: Kimi Code CLI
 - Branch: feature/change-build-time-disable-sessions
 - Polished: 2026-07-11
@@ -67,3 +67,33 @@ Medium。必須機能ではない Sessions をデフォルト無効化し、必�
 - CI / E2E / unit test は `VITE_ENABLE_SESSIONS=true` で実行され、既存の Sessions 関連テストが通る
 - CI に無効ビルド用のビルド検証ステップを追加し、無効ビルドが成功することを確認する
 - 変更履歴を `CHANGES.md` に追記する（例：`- [CHANGE] Sessions 機能をビルド時にデフォルト無効化し、環境変数で有効化できるようにする`）
+
+## 解決方法
+
+設計方針どおり、Vite の `define` で埋め込むビルド時定数 `__SESSIONS_ENABLED__` による切り替えを実装した。
+
+- `vite.config.ts` をコールバック形式に変更し、`loadEnv(mode, rootDir, "VITE_")` + `process.env.VITE_ENABLE_SESSIONS` の優先マージで `define: { __SESSIONS_ENABLED__ }` を設定した
+- 新規 `src/sessionDatabaseLoader.ts` に `sessionDatabase.ts` への全アクセスを集約し、動的 import + no-op フォールバックを実装した
+  - 無効ビルドでは全 API が no-op（`null` / `false` / `void`）になる
+  - 動的 import が失敗した場合はキャッシュをリセットして再試行可能にし、各 API は no-op にフォールバックする（永続化失敗でも接続は継続する従来の契約を維持）
+  - モジュールのロード成功時に実モジュールの `createSessionDatabase()` を冪等に呼び、`whenReady()` が必ず settle するようにした
+- `src/app/actions.ts` の import 元を `sessionDatabase.ts` から `sessionDatabaseLoader.ts` に切り替えた
+- `src/App.tsx` の `/sessions` ルートと `createSessionDatabase()` 呼び出しをガードし、`src/components/Header/index.tsx` の Sessions ボタン表示を `SESSIONS_ENABLED` で切り替えた
+- 新規 `src/sessionDatabaseLoader.test.ts` でラッパーの no-op 契約を検証した（無効ビルド時のみ実行、有効ビルドでは `test.skipIf` で skip）
+- `playwright.config.ts` の `webServer.env` に `VITE_ENABLE_SESSIONS: "true"` を追加し、ローカル E2E でも Sessions が有効になるようにした
+- CI に無効ビルドの検証ステップ（アセット不在チェック + 無効モードでの unit test）を追加し、CI / E2E / デプロイの各ワークフローで `VITE_ENABLE_SESSIONS=true` を設定した
+
+設計方針からの主な乖離と理由:
+
+- 動的 import のガードは `SESSIONS_ENABLED`（`src/constants.ts` 経由）ではなく `__SESSIONS_ENABLED__` の直接参照とした。クロスモジュールの定数経由だとバンドラのデッドコード除去が効かず、無効ビルドにも Sessions 関連 chunk が出力されてしまうため。`SESSIONS_ENABLED` は UI の表示切り替え専用とした
+- `/sessions` の `Route` は `&&` による条件描画ではなく配列での分岐とした。preact-iso の `Router` の children 型が `NestedArray<VNode>` であり、`false | Element` では型エラーになるため
+- `src/App.tsx` から `createSessionDatabase` の import は除去せず、loader への静的 import + `__SESSIONS_ENABLED__` ガードとした。loader 自体が no-op を持つため簡潔になり、無効ビルドでは実モジュールへの動的 import が到達不能になる
+- `src/vite-env.d.ts` の `ImportMetaEnv` への `VITE_ENABLE_SESSIONS` 宣言は、`import.meta.env` 経由で読むコードが存在せず未使用となるため追加しなかった
+- `e2e-test.yml` の Playwright 実行ステップへの `VITE_ENABLE_SESSIONS` 設定は、`playwright.config.ts` の `webServer.env` で恒常有効化されるため冗長となり、追加しなかった（`vp build` ステップ側には設定済み）
+- 無効ビルド検証の grep パターンに `Sessions|sessionDatabase` を追加し、Sessions ページ関連の chunk も検証対象にした
+
+検証:
+
+- 無効ビルドで Sessions ボタン非表示、`/sessions` が default route で DevTools 表示、`dist/assets` に Sessions 関連アセットが無いことをブラウザ実機と grep で確認した
+- 有効ビルドで Sessions ボタン表示、`/sessions` ページ表示、関連 chunk 生成を確認した
+- unit test（有効・無効両モード）、component test、`vp check` が全て通過することを確認した

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,5 +40,9 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     stdout: "pipe",
     stderr: "pipe",
+    // Sessions 機能を前提とする E2E が存在するため、dev server では常に有効化する
+    env: {
+      VITE_ENABLE_SESSIONS: "true",
+    },
   },
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,11 +9,13 @@ import {
 } from "@/app/actions";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
-import { createSessionDatabase } from "@/sessionDatabase";
+import { createSessionDatabase } from "@/sessionDatabaseLoader";
 
 import DevTools from "./DevTools.tsx";
 
-const Sessions = lazy(async () => import("./routes/Sessions.tsx"));
+// /sessions ページの lazy import。ガードに __SESSIONS_ENABLED__ を直接使う
+// （理由は sessionDatabaseLoader.ts 冒頭のコメントを参照）
+const Sessions = __SESSIONS_ENABLED__ ? lazy(async () => import("./routes/Sessions.tsx")) : null;
 
 // タブ閉鎖・リロード時に Sora 切断を試行する
 // sessionDatabase.close() は呼ばない（beforeunload での close 競合を避ける方針）
@@ -28,7 +30,9 @@ function App() {
     void setMediaDevices();
     void unregisterServiceWorker();
     // セッション永続化 DB の初期化を非同期で開始する（Connect を待たない）
-    void createSessionDatabase();
+    if (__SESSIONS_ENABLED__) {
+      void createSessionDatabase();
+    }
     globalThis.addEventListener("beforeunload", handleBeforeUnload);
     return () => {
       globalThis.removeEventListener("beforeunload", handleBeforeUnload);
@@ -41,7 +45,11 @@ function App() {
       <ErrorBoundary>
         <Router>
           <Route path="/" component={DevTools} />
-          <Route path="/sessions" component={Sessions} />
+          {/* preact-iso の Router の children 型が NestedArray<VNode> のため、
+              && による条件描画ではなく配列で分岐する */}
+          {Sessions !== null
+            ? [<Route key="sessions" path="/sessions" component={Sessions} />]
+            : []}
           <Route default component={DevTools} />
         </Router>
       </ErrorBoundary>

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -48,7 +48,7 @@ import {
   updateConnectionEndedAt,
   updateSessionEndedAt,
   updateSessionIdAndConnectionId,
-} from "./../sessionDatabase.ts";
+} from "./../sessionDatabaseLoader.ts";
 import { normalizeWebrtcStats } from "./../webrtcStatsNormalizer.ts";
 import * as signals from "./signals.ts";
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,6 +3,7 @@ import { useRef } from "preact/hooks";
 
 import { connectionStatus, signalingUrlCandidates, sora, turnUrl } from "@/app/signals";
 import { Navbar, NavbarBrand, NavbarCollapse, NavbarText, NavbarToggle } from "@/components/ui";
+import { SESSIONS_ENABLED } from "@/constants";
 
 import { CopyUrlButton } from "./CopyUrlButton.tsx";
 import { DebugButton } from "./DebugButton.tsx";
@@ -74,9 +75,11 @@ export function Header() {
               <NavbarText className="py-0 my-1 mx-1">
                 <DownloadReportButton />
               </NavbarText>
-              <NavbarText className="py-0 my-1 mx-1">
-                <SessionsButton />
-              </NavbarText>
+              {SESSIONS_ENABLED && (
+                <NavbarText className="py-0 my-1 mx-1">
+                  <SessionsButton />
+                </NavbarText>
+              )}
               <NavbarText className="py-0 my-1 ml-1">
                 <CopyUrlButton />
               </NavbarText>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -114,3 +114,9 @@ export const ROLES = ["sendrecv", "sendonly", "recvonly"] as const;
 export const FACING_MODES = ["", "front", "back"] as const;
 
 export const INSTRUCTIONS = instructionsJSON as Record<string, { description: string } | null>;
+
+// ビルド時に Vite の define で埋め込まれる Sessions 機能の有効フラグ
+// VITE_ENABLE_SESSIONS=true のビルドでのみ true になる
+// UI の表示切り替え専用。動的 import のガードには __SESSIONS_ENABLED__ を直接使うこと
+// （理由は sessionDatabaseLoader.ts 冒頭のコメントを参照）
+export const SESSIONS_ENABLED = __SESSIONS_ENABLED__;

--- a/src/sessionDatabaseLoader.test.ts
+++ b/src/sessionDatabaseLoader.test.ts
@@ -1,0 +1,74 @@
+import { assert, test } from "vite-plus/test";
+
+import {
+  createSessionDatabase,
+  enqueueStats,
+  flushStatsBuffer,
+  getCurrentConnectionId,
+  getCurrentSessionDbId,
+  insertConnection,
+  insertSession,
+  updateConnectionEndedAt,
+  updateSessionEndedAt,
+  updateSessionIdAndConnectionId,
+} from "./sessionDatabaseLoader.ts";
+
+// ラッパーの no-op 契約を検証するテスト
+// 無効ビルド（VITE_ENABLE_SESSIONS 未設定）では全 API が no-op になる。
+// 有効ビルドでは実モジュールへ委譲されるため no-op の検証は skip し、
+// 実モジュール側の挙動は sessionDatabase.test.ts で検証する
+const sessionsEnabled = __SESSIONS_ENABLED__;
+
+// 初期状態の確認はビルドモードに依らず成立する
+test("getCurrentSessionDbId は初期状態で null を返す", () => {
+  assert.equal(getCurrentSessionDbId(), null);
+});
+
+test("getCurrentConnectionId は初期状態で null を返す", () => {
+  assert.equal(getCurrentConnectionId(), null);
+});
+
+test("enqueueStats は未ロード状態でも例外を投げない", () => {
+  // 無効ビルドではガードで no-op、有効ビルドでもモジュール未ロード時は no-op
+  enqueueStats([], 1, null, null, "channel-id");
+});
+
+test.skipIf(sessionsEnabled)("createSessionDatabase は無効ビルドで no-op になる", async () => {
+  await createSessionDatabase();
+});
+
+test.skipIf(sessionsEnabled)("insertSession は無効ビルドで null を返す", async () => {
+  const result = await insertSession("channel-id", "sendrecv", {});
+  assert.equal(result, null);
+});
+
+test.skipIf(sessionsEnabled)(
+  "updateSessionIdAndConnectionId は無効ビルドで no-op になる",
+  async () => {
+    await updateSessionIdAndConnectionId(1, "session-id", "connection-id");
+  },
+);
+
+test.skipIf(sessionsEnabled)("insertConnection は無効ビルドで false を返す", async () => {
+  const result = await insertConnection(
+    1,
+    "session-id",
+    "connection-id",
+    "sora-client-id",
+    "channel-id",
+    "wss://example.com/signaling",
+  );
+  assert.equal(result, false);
+});
+
+test.skipIf(sessionsEnabled)("updateSessionEndedAt は無効ビルドで no-op になる", async () => {
+  await updateSessionEndedAt(1);
+});
+
+test.skipIf(sessionsEnabled)("updateConnectionEndedAt は無効ビルドで no-op になる", async () => {
+  await updateConnectionEndedAt("connection-id");
+});
+
+test.skipIf(sessionsEnabled)("flushStatsBuffer は無効ビルドで no-op になる", async () => {
+  await flushStatsBuffer();
+});

--- a/src/sessionDatabaseLoader.ts
+++ b/src/sessionDatabaseLoader.ts
@@ -1,0 +1,170 @@
+// Sessions 機能（DuckDB-Wasm + OPFS 永続化）のビルド時切り替えラッパー
+//
+// 無効ビルドでは各 API が no-op となり、既存の接続・デバッグ機能はそのまま動作する。
+// ガードには constants の SESSIONS_ENABLED ではなくビルド時定数 __SESSIONS_ENABLED__ を
+// 直接使う。クロスモジュールの定数経由だとバンドラのデッドコード除去が効かず、
+// 動的 import の対象が chunk として出力されてしまうため。
+// ここの import("@/sessionDatabase") がデッドコードになれば、
+// DuckDB-Wasm / Apache Arrow / uPlot の chunk は無効ビルドに含まれない。
+//
+// 動的 import が失敗した場合（デプロイ後のキャッシュ切れによる旧 chunk の 404 等）は
+// 各 API が no-op にフォールバックする。永続化が失敗しても接続自体は継続する、
+// という従来の createSessionDatabase の契約を維持するため。
+
+import type * as sessionDatabaseModule from "@/sessionDatabase";
+import type { Json } from "@/types";
+import type { NormalizedWebrtcStat } from "@/webrtcStatsNormalizer";
+
+type SessionDatabaseModule = typeof sessionDatabaseModule;
+
+// 動的 import したモジュールのキャッシュ。同期 API はこのキャッシュ経由で応答する
+let databaseModule: SessionDatabaseModule | null = null;
+let loadPromise: Promise<SessionDatabaseModule | null> | null = null;
+
+async function loadSessionDatabase(): Promise<SessionDatabaseModule | null> {
+  loadPromise ??= (async () => {
+    try {
+      const loaded = await import("@/sessionDatabase");
+      databaseModule = loaded;
+      // 初期化をここで開始しておく。これを呼ばないと実モジュール側の whenReady() が
+      // settle せず、insertSession 等の書き込み API が永久に待機する。
+      // 実モジュール側は initStarted ガードで冪等なので、App からの呼び出しと重複してもよい
+      void loaded.createSessionDatabase();
+      return loaded;
+    } catch (error) {
+      // 失敗時はキャッシュをリセットして次回呼び出しで再試行できるようにする
+      console.warn("Failed to load session database module", error);
+      loadPromise = null;
+      return null;
+    }
+  })();
+  return loadPromise;
+}
+
+// 有効ビルドではモジュール評価時に読み込みを開始し、接続開始までにロードを済ませる
+if (__SESSIONS_ENABLED__) {
+  void loadSessionDatabase();
+}
+
+// App マウント時に呼ぶ
+export async function createSessionDatabase(): Promise<void> {
+  if (!__SESSIONS_ENABLED__) {
+    return;
+  }
+  const sessionDatabase = await loadSessionDatabase();
+  if (sessionDatabase === null) {
+    return;
+  }
+  await sessionDatabase.createSessionDatabase();
+}
+
+export function getCurrentSessionDbId(): number | null {
+  return databaseModule?.getCurrentSessionDbId() ?? null;
+}
+
+export function getCurrentConnectionId(): string | null {
+  return databaseModule?.getCurrentConnectionId() ?? null;
+}
+
+export async function insertSession(
+  channelId: string,
+  role: string,
+  metadata: Json | undefined,
+): Promise<number | null> {
+  if (!__SESSIONS_ENABLED__) {
+    return null;
+  }
+  const sessionDatabase = await loadSessionDatabase();
+  if (sessionDatabase === null) {
+    return null;
+  }
+  return sessionDatabase.insertSession(channelId, role, metadata);
+}
+
+export async function updateSessionIdAndConnectionId(
+  id: number,
+  sessionId: string,
+  connectionId: string,
+): Promise<void> {
+  if (!__SESSIONS_ENABLED__) {
+    return;
+  }
+  const sessionDatabase = await loadSessionDatabase();
+  if (sessionDatabase === null) {
+    return;
+  }
+  await sessionDatabase.updateSessionIdAndConnectionId(id, sessionId, connectionId);
+}
+
+export async function insertConnection(
+  sessionDbId: number,
+  sessionId: string,
+  connectionId: string,
+  soraClientId: string,
+  channelId: string,
+  signalingUrl: string,
+): Promise<boolean> {
+  if (!__SESSIONS_ENABLED__) {
+    return false;
+  }
+  const sessionDatabase = await loadSessionDatabase();
+  if (sessionDatabase === null) {
+    return false;
+  }
+  return sessionDatabase.insertConnection(
+    sessionDbId,
+    sessionId,
+    connectionId,
+    soraClientId,
+    channelId,
+    signalingUrl,
+  );
+}
+
+export async function updateSessionEndedAt(id: number): Promise<void> {
+  if (!__SESSIONS_ENABLED__) {
+    return;
+  }
+  const sessionDatabase = await loadSessionDatabase();
+  if (sessionDatabase === null) {
+    return;
+  }
+  await sessionDatabase.updateSessionEndedAt(id);
+}
+
+export async function updateConnectionEndedAt(connectionId: string): Promise<void> {
+  if (!__SESSIONS_ENABLED__) {
+    return;
+  }
+  const sessionDatabase = await loadSessionDatabase();
+  if (sessionDatabase === null) {
+    return;
+  }
+  await sessionDatabase.updateConnectionEndedAt(connectionId);
+}
+
+export async function flushStatsBuffer(sessionDbId?: number): Promise<void> {
+  if (!__SESSIONS_ENABLED__) {
+    return;
+  }
+  const sessionDatabase = await loadSessionDatabase();
+  if (sessionDatabase === null) {
+    return;
+  }
+  await sessionDatabase.flushStatsBuffer(sessionDbId);
+}
+
+// 同期 API。モジュール未ロード時は no-op とする
+// 有効ビルドではトップレベルで preload しているため、接続後の呼び出しではロード済み
+export function enqueueStats(
+  normalizedStats: NormalizedWebrtcStat[],
+  sessionDbId: number,
+  sessionId: string | null,
+  connectionId: string | null,
+  channelId: string,
+): void {
+  if (!__SESSIONS_ENABLED__ || databaseModule === null) {
+    return;
+  }
+  databaseModule.enqueueStats(normalizedStats, sessionDbId, sessionId, connectionId, channelId);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,8 @@
 /// <reference types="vite/client" />
 
+// vite.config.ts の define でビルド時に埋め込まれる定数
+declare const __SESSIONS_ENABLED__: boolean;
+
 interface ImportMetaEnv {
   readonly VITE_SORA_SIGNALING_URL: string;
   readonly VITE_VIRTUAL_BACKGROUND_ASSETS_PATH: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import preactPlugin from "@preact/preset-vite";
 import tailwindcss from "@tailwindcss/vite";
-import { createLogger, defineConfig } from "vite-plus";
+import { createLogger, defineConfig, loadEnv } from "vite-plus";
 
 const rootDir = import.meta.dirname;
 
@@ -21,7 +21,7 @@ logger.warnOnce = (msg, options) => {
   warnOnce(msg, options);
 };
 
-export default defineConfig({
+const baseConfig = defineConfig({
   customLogger: logger,
   plugins: [preactPlugin(), tailwindcss()],
   build: {
@@ -113,6 +113,8 @@ export default defineConfig({
       curly: "error",
       // for-in ループで hasOwnProperty チェックを強制
       "guard-for-in": "error",
+      // ビルド時定数の __NAME__ 形式を許可
+      "no-underscore-dangle": ["error", { allow: ["__SESSIONS_ENABLED__"] }],
 
       // ===== eslint: 非推奨機能の禁止 =====
       // arguments.caller/callee の使用を禁止
@@ -1016,4 +1018,21 @@ export default defineConfig({
   fmt: {
     ignorePatterns: ["dist/**"],
   },
+});
+
+// Sessions 機能のビルド時切り替え。VITE_ENABLE_SESSIONS=true のビルドでのみ有効化する
+export default defineConfig(({ mode }) => {
+  // .env ファイルから VITE_ プレフィックスの環境変数を読み込む
+  const env = loadEnv(mode, rootDir, "VITE_");
+  // CI / ワークフローで渡される環境変数を .env ファイルの値より優先する
+  if (process.env.VITE_ENABLE_SESSIONS !== undefined) {
+    env.VITE_ENABLE_SESSIONS = process.env.VITE_ENABLE_SESSIONS;
+  }
+  return {
+    ...baseConfig,
+    define: {
+      // 実行時には boolean リテラルとして埋め込まれる
+      __SESSIONS_ENABLED__: JSON.stringify(env.VITE_ENABLE_SESSIONS === "true"),
+    },
+  };
 });

--- a/vitest.ct.config.ts
+++ b/vitest.ct.config.ts
@@ -8,6 +8,10 @@ const rootDir = import.meta.dirname;
 
 export default defineConfig({
   plugins: [preactPlugin(), tailwindcss()],
+  // ブラウザテストにもビルド時定数を埋め込む（既定は無効）
+  define: {
+    __SESSIONS_ENABLED__: JSON.stringify(process.env.VITE_ENABLE_SESSIONS === "true"),
+  },
   resolve: {
     alias: {
       "@": path.resolve(rootDir, "./src"),


### PR DESCRIPTION
## 概要

DuckDB-Wasm を使った Sessions 機能を、ビルド時に環境変数 `VITE_ENABLE_SESSIONS` で有効化・無効化できるようにする。デフォルトは無効とし、無効ビルドでは Sessions 関連の chunk を含まない。

## 変更内容

- Vite の `define` でビルド時定数 `__SESSIONS_ENABLED__` を埋め込み、`VITE_ENABLE_SESSIONS=true` のビルドでのみ Sessions 機能を有効化する
- 新規 `src/sessionDatabaseLoader.ts` に `sessionDatabase.ts` への全アクセスを集約し、無効ビルドでは no-op にフォールバックする
- 動的 import 失敗時は再試行可能にし、各 API は no-op にフォールバックする（永続化失敗でも接続は継続する従来の契約を維持）
- `/sessions` ルート・Sessions ボタン・`createSessionDatabase()` 呼び出しをビルド時定数でゲートする
- ラッパーの no-op 契約を検証する unit test を追加する
- `playwright.config.ts` の `webServer.env` で E2E の dev server を常に Sessions 有効で起動する
- CI に無効ビルドの検証ステップ（アセット不在チェック + 無効モードの unit test）を追加し、CI / E2E / デプロイで `VITE_ENABLE_SESSIONS=true` を設定する

## 完了条件

- [x] `VITE_ENABLE_SESSIONS` 未定義または `"true"` 以外でビルドした場合、Sessions ボタンが表示されず、`/sessions` へアクセスしても default route がマッチし DevTools が表示される
- [x] 無効ビルドの `dist/assets` に `duckdb-mvp`、`duckdb-eh`、`duckdb-wasm`、`apache-arrow`、`uplot` 関連のファイルが含まれない
- [x] `VITE_ENABLE_SESSIONS=true` でビルドした場合、既存の Sessions 機能が動作する
- [x] CI / E2E / unit test は `VITE_ENABLE_SESSIONS=true` で実行され、既存の Sessions 関連テストが通る
- [x] CI に無効ビルド用のビルド検証ステップを追加し、無効ビルドが成功することを確認する
- [x] 変更履歴を `CHANGES.md` に追記する

## 関連 issue

- issues/closed/0072-change-build-time-disable-sessions.md