### PR TITLE
/sessions に行単位削除と履歴削除（OPFS 再作成）を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [CHANGE] Sessions 機能をビルド時にデフォルト無効化し、環境変数で有効化できるようにする
   - @voluntas
+- [ADD] /sessions にセッション行の削除と履歴削除（OPFS 再作成）を追加する
+  - @voluntas
 - [ADD] /sessions ページに過去セッション一覧・詳細・フィルタ UI を実装する
   - @voluntas
 - [ADD] uPlot を導入して Sessions の時系列チャートを 1 秒単位で描画する

--- a/issues/closed/0073-add-sessions-delete-ui.md
+++ b/issues/closed/0073-add-sessions-delete-ui.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-07-14
-- Completed: YYYY-MM-DD
+- Completed: 2026-07-14
 - Model: Composer 2.5
 - Branch: feature/add-sessions-delete-ui
 - Polished: 2026-07-14
@@ -178,11 +178,10 @@ Medium。#0065 が第 1 段階の必須機能から意図的に外した「全�
 
 ## 解決方法
 
-1. 失敗する Playwright E2E（DB 層・UI 層）を先に追加する
-2. `src/sessionDatabase.ts` に `deleteSession` / `resetSessionDatabase`（`resetInProgress` 含む）を実装し、`flushOneStatsBuffer` の孤児 INSERT ガードを入れる
-3. `SessionList.tsx` に操作カラムと行確認帯、`Sessions.tsx` に履歴削除確認帯・`loadSessions`・`errorKind` 付きエラー表示を配線する
-4. `CHANGES.md` を更新する
-5. `vp check` / テストを通し、動作を確認する
+1. `src/sessionDatabase.ts` に `deleteSession` / `resetSessionDatabase` を追加し、`resetInProgress` 中は `insertSession` が DB へ書かないようにした。`flushOneStatsBuffer` では削除済み id の抽出済みバッチを INSERT しないガードを入れた
+2. `SessionList.tsx` に行削除ボタンと 2 段確認 UI を追加した。`Sessions.tsx` に履歴削除・`loadSessions`（世代キャンセル）・`errorKind` 付きエラー表示を配線した
+3. Playwright E2E でカスケード削除・current 拒否（行削除・履歴削除）・履歴削除後の再記録・接続中 disabled・確認キャンセルを検証した
+4. `CHANGES.md` の `## develop` に `[ADD]` を追記した
 
 ## 関連 issue
 

--- a/src/components/Sessions/SessionList.tsx
+++ b/src/components/Sessions/SessionList.tsx
@@ -8,6 +8,12 @@ export interface SessionListProps {
   currentSessionDbId: number | null;
   selectedSessionDbId: number | undefined;
   onSelect: (sessionDbId: number) => void;
+  onRequestDelete: (sessionDbId: number) => void;
+  onConfirmDelete: (sessionDbId: number) => void;
+  onCancelDelete: () => void;
+  confirmingSessionDbId: number | null;
+  deletingSessionDbId: number | null;
+  deleteActionsDisabled: boolean;
 }
 
 function displayOrDash(value: string | null): string {
@@ -23,6 +29,12 @@ export const SessionList: FunctionComponent<SessionListProps> = ({
   currentSessionDbId,
   selectedSessionDbId,
   onSelect,
+  onRequestDelete,
+  onConfirmDelete,
+  onCancelDelete,
+  confirmingSessionDbId,
+  deletingSessionDbId,
+  deleteActionsDisabled,
 }) => {
   if (sessions.length === 0) {
     return (
@@ -42,6 +54,7 @@ export const SessionList: FunctionComponent<SessionListProps> = ({
             <th className="px-2 py-1">started_at</th>
             <th className="px-2 py-1">ended_at</th>
             <th className="px-2 py-1">状態</th>
+            <th className="px-2 py-1">操作</th>
           </tr>
         </thead>
         <tbody>
@@ -52,6 +65,69 @@ export const SessionList: FunctionComponent<SessionListProps> = ({
             if (selected) {
               rowClass = "border-b border-bs-light cursor-pointer bg-[#e7f1ff]";
             }
+            const confirming = confirmingSessionDbId === session.id;
+            const deleting = deletingSessionDbId === session.id;
+            const showDeleteButton = status !== "connected";
+
+            let actionCell = null;
+            if (showDeleteButton) {
+              if (confirming) {
+                actionCell = (
+                  <div
+                    className="flex flex-wrap items-center gap-1"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                    }}
+                  >
+                    <span className="text-xs text-bs-secondary">本当に削除しますか？</span>
+                    <button
+                      type="button"
+                      className="rounded border border-red-400 px-2 py-0.5 text-xs text-red-700"
+                      data-testid={`session-delete-confirm-${session.id}`}
+                      disabled={deleting || deleteActionsDisabled}
+                      onClick={() => {
+                        onConfirmDelete(session.id);
+                      }}
+                    >
+                      削除する
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded border border-bs-secondary px-2 py-0.5 text-xs"
+                      data-testid={`session-delete-cancel-${session.id}`}
+                      disabled={deleting || deleteActionsDisabled}
+                      onClick={() => {
+                        onCancelDelete();
+                      }}
+                    >
+                      キャンセル
+                    </button>
+                  </div>
+                );
+              } else {
+                actionCell = (
+                  <div
+                    className="flex flex-wrap items-center gap-1"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                    }}
+                  >
+                    <button
+                      type="button"
+                      className="rounded border border-bs-secondary px-2 py-0.5 text-xs"
+                      data-testid={`session-delete-${session.id}`}
+                      disabled={deleteActionsDisabled}
+                      onClick={() => {
+                        onRequestDelete(session.id);
+                      }}
+                    >
+                      削除
+                    </button>
+                  </div>
+                );
+              }
+            }
+
             return (
               <tr
                 key={session.id}
@@ -69,6 +145,7 @@ export const SessionList: FunctionComponent<SessionListProps> = ({
                 <td className="px-2 py-1" data-testid={`session-status-${session.id}`}>
                   {sessionStatusLabel(status)}
                 </td>
+                <td className="px-2 py-1">{actionCell}</td>
               </tr>
             );
           })}

--- a/src/routes/Sessions.tsx
+++ b/src/routes/Sessions.tsx
@@ -1,23 +1,31 @@
 import type { FunctionComponent } from "preact";
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import { useLocation } from "preact-iso";
 
+import { connectionStatus } from "@/app/signals";
 import { SessionDetail } from "@/components/Sessions/SessionDetail";
 import { SessionFilter } from "@/components/Sessions/SessionFilter";
 import { SessionList } from "@/components/Sessions/SessionList";
 import {
+  deleteSession,
   getCurrentSessionDbId,
   isSessionDatabaseAvailable,
   listSessions,
+  resetSessionDatabase,
   whenReady,
 } from "@/sessionDatabase";
-import type { SessionListRow } from "@/sessionDatabase";
+import type { SessionListFilter, SessionListRow } from "@/sessionDatabase";
 import { buildSessionsPath, parseSessionsSearchParams } from "@/sessionsSearchParams";
 import type { SessionsSearchParams } from "@/sessionsSearchParams";
 
+type SessionsErrorKind = "list" | "delete" | "reset";
+
 // 不正な QS が落ちたときだけ URL を正規化する（パラメータ順の差では置換しない）
 function shouldNormalizeSearch(search: string, parsed: SessionsSearchParams): boolean {
-  const normalized = search.startsWith("?") ? search.slice(1) : search;
+  let normalized = search;
+  if (search.startsWith("?")) {
+    normalized = search.slice(1);
+  }
   const raw = new URLSearchParams(normalized);
 
   const rawSessionDbId = raw.get("sessionDbId");
@@ -34,6 +42,66 @@ function shouldNormalizeSearch(search: string, parsed: SessionsSearchParams): bo
     return true;
   }
 
+  return false;
+}
+
+function errorPrefix(kind: SessionsErrorKind): string {
+  if (kind === "delete") {
+    return "セッションの削除に失敗しました: ";
+  }
+  if (kind === "reset") {
+    return "履歴の削除に失敗しました: ";
+  }
+  return "セッション一覧の読み取りに失敗しました: ";
+}
+
+function errorMessageFromUnknown(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+}
+
+function buildListFilter(params: SessionsSearchParams): SessionListFilter {
+  const filter: SessionListFilter = {};
+  if (params.sessionId !== undefined) {
+    filter.sessionId = params.sessionId;
+  }
+  if (params.connectionId !== undefined) {
+    filter.connectionId = params.connectionId;
+  }
+  if (params.channelId !== undefined) {
+    filter.channelId = params.channelId;
+  }
+  if (params.from !== undefined) {
+    filter.from = params.from;
+  }
+  if (params.to !== undefined) {
+    filter.to = params.to;
+  }
+  return filter;
+}
+
+function withoutSessionDbId(params: SessionsSearchParams): SessionsSearchParams {
+  const next: SessionsSearchParams = { ...params };
+  delete next.sessionDbId;
+  return next;
+}
+
+function isHistoryResetDisabled(
+  deleteActionsDisabled: boolean,
+  liveCurrent: number | null,
+  connectionStatusValue: string,
+): boolean {
+  if (deleteActionsDisabled) {
+    return true;
+  }
+  if (liveCurrent !== null) {
+    return true;
+  }
+  if (connectionStatusValue !== "disconnected") {
+    return true;
+  }
   return false;
 }
 
@@ -55,6 +123,7 @@ function PrivacyNotice() {
 
 const Sessions: FunctionComponent = () => {
   const { url, route } = useLocation();
+  const connectionStatusValue = connectionStatus.value;
   const [searchParams, setSearchParams] = useState<SessionsSearchParams>(() =>
     parseSessionsSearchParams(globalThis.location.search),
   );
@@ -62,73 +131,74 @@ const Sessions: FunctionComponent = () => {
   const [currentSessionDbId, setCurrentSessionDbId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [databaseAvailable, setDatabaseAvailable] = useState(true);
+  const [errorKind, setErrorKind] = useState<SessionsErrorKind>("list");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [confirmingSessionDbId, setConfirmingSessionDbId] = useState<number | null>(null);
+  const [deletingSessionDbId, setDeletingSessionDbId] = useState<number | null>(null);
+  const [confirmingReset, setConfirmingReset] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const loadGenerationRef = useRef(0);
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
 
-  // URL 変更に追従してフィルタ状態を同期し、不正値は正規化する
+  const applySearchParams = (next: SessionsSearchParams): void => {
+    route(buildSessionsPath(next), true);
+  };
+
+  const loadSessions = async (options?: { clearError?: boolean }): Promise<void> => {
+    const generation = loadGenerationRef.current + 1;
+    loadGenerationRef.current = generation;
+    setLoading(true);
+    if (options?.clearError === true) {
+      setErrorMessage(null);
+    }
+    try {
+      await whenReady();
+      if (generation !== loadGenerationRef.current) {
+        return;
+      }
+      const available = isSessionDatabaseAvailable();
+      setDatabaseAvailable(available);
+      if (!available) {
+        setSessions([]);
+        setCurrentSessionDbId(null);
+        setLoading(false);
+        return;
+      }
+      const rows = await listSessions(buildListFilter(searchParamsRef.current));
+      if (generation !== loadGenerationRef.current) {
+        return;
+      }
+      setSessions(rows);
+      setCurrentSessionDbId(getCurrentSessionDbId());
+      setLoading(false);
+    } catch (error) {
+      if (generation !== loadGenerationRef.current) {
+        return;
+      }
+      const message = errorMessageFromUnknown(error, "Failed to load session list");
+      console.warn(`Session list load failed: ${message}`);
+      setErrorKind("list");
+      setErrorMessage(message);
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
-    // preact-iso の url だけを見る（location.search フォールバックは DevTools QS 混入の原因になる）
     const searchIndex = url.indexOf("?");
-    const search = searchIndex === -1 ? "" : url.slice(searchIndex);
+    let search = "";
+    if (searchIndex !== -1) {
+      search = url.slice(searchIndex);
+    }
     const parsed = parseSessionsSearchParams(search);
     setSearchParams(parsed);
-
     if (shouldNormalizeSearch(search, parsed)) {
       route(buildSessionsPath(parsed), true);
     }
   }, [url, route]);
 
-  // マウント時・フィルタ変更時に一覧を再取得する
   useEffect(() => {
-    const active = { cancelled: false };
-    setLoading(true);
-    setErrorMessage(null);
-
-    void (async () => {
-      try {
-        await whenReady();
-        if (active.cancelled) {
-          return;
-        }
-        const available = isSessionDatabaseAvailable();
-        setDatabaseAvailable(available);
-        if (!available) {
-          setSessions([]);
-          setCurrentSessionDbId(null);
-          setLoading(false);
-          return;
-        }
-        const filter = {
-          ...(searchParams.sessionId !== undefined ? { sessionId: searchParams.sessionId } : {}),
-          ...(searchParams.connectionId !== undefined
-            ? { connectionId: searchParams.connectionId }
-            : {}),
-          ...(searchParams.channelId !== undefined ? { channelId: searchParams.channelId } : {}),
-          ...(searchParams.from !== undefined ? { from: searchParams.from } : {}),
-          ...(searchParams.to !== undefined ? { to: searchParams.to } : {}),
-        };
-        const rows = await listSessions(filter);
-        // await 中に cleanup で cancelled が立つ可能性がある
-        // oxlint-disable-next-line typescript/no-unnecessary-condition
-        if (active.cancelled) {
-          return;
-        }
-        setSessions(rows);
-        setCurrentSessionDbId(getCurrentSessionDbId());
-        setLoading(false);
-      } catch (error) {
-        if (active.cancelled) {
-          return;
-        }
-        const message = error instanceof Error ? error.message : "Failed to load session list";
-        console.warn(`Session list load failed: ${message}`);
-        setErrorMessage(message);
-        setLoading(false);
-      }
-    })();
-
-    return () => {
-      active.cancelled = true;
-    };
+    void loadSessions({ clearError: true });
   }, [
     searchParams.sessionId,
     searchParams.connectionId,
@@ -137,60 +207,201 @@ const Sessions: FunctionComponent = () => {
     searchParams.to,
   ]);
 
-  const applySearchParams = (next: SessionsSearchParams): void => {
-    const path = buildSessionsPath(next);
-    route(path, true);
+  const handleConfirmDelete = (sessionDbId: number): void => {
+    void (async () => {
+      if (getCurrentSessionDbId() === sessionDbId) {
+        setErrorKind("delete");
+        setErrorMessage(`Cannot delete session: sessionDbId ${sessionDbId} is the current session`);
+        setConfirmingSessionDbId(null);
+        return;
+      }
+      setDeletingSessionDbId(sessionDbId);
+      setErrorMessage(null);
+      try {
+        await deleteSession(sessionDbId);
+        setConfirmingSessionDbId(null);
+        if (searchParams.sessionDbId === sessionDbId) {
+          applySearchParams(withoutSessionDbId(searchParams));
+        }
+        await loadSessions();
+      } catch (error) {
+        const message = errorMessageFromUnknown(error, "Failed to delete session");
+        console.warn(`Session delete failed: ${message}`);
+        setErrorKind("delete");
+        setErrorMessage(message);
+      } finally {
+        setDeletingSessionDbId(null);
+      }
+    })();
   };
 
-  const handleSelect = (sessionDbId: number): void => {
-    applySearchParams({ ...searchParams, sessionDbId });
+  const handleConfirmReset = (): void => {
+    void (async () => {
+      if (getCurrentSessionDbId() !== null) {
+        setErrorKind("reset");
+        setErrorMessage("Cannot reset session database: a session is in progress");
+        setConfirmingReset(false);
+        return;
+      }
+      setResetting(true);
+      setErrorMessage(null);
+      try {
+        await resetSessionDatabase();
+        setConfirmingReset(false);
+        if (searchParams.sessionDbId !== undefined) {
+          applySearchParams(withoutSessionDbId(searchParams));
+        }
+        await loadSessions();
+      } catch (error) {
+        const message = errorMessageFromUnknown(error, "Failed to reset session database");
+        console.warn(`Session database reset failed: ${message}`);
+        setErrorKind("reset");
+        setErrorMessage(message);
+        setConfirmingReset(false);
+        if (searchParams.sessionDbId !== undefined) {
+          applySearchParams(withoutSessionDbId(searchParams));
+        }
+        const available = isSessionDatabaseAvailable();
+        setDatabaseAvailable(available);
+        if (!available) {
+          setSessions([]);
+          setCurrentSessionDbId(null);
+        } else {
+          await loadSessions();
+        }
+      } finally {
+        setResetting(false);
+      }
+    })();
   };
+
+  const deleteActionsDisabled = deletingSessionDbId !== null || resetting;
+  const resetDisabled = isHistoryResetDisabled(
+    deleteActionsDisabled,
+    getCurrentSessionDbId(),
+    connectionStatusValue,
+  );
+  const showDeleteUi = !loading && databaseAvailable;
+
+  let errorAlert = null;
+  if (errorMessage !== null) {
+    errorAlert = (
+      <div
+        className="mb-4 rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800"
+        data-testid="sessions-page-error"
+        role="alert"
+      >
+        {errorPrefix(errorKind)}
+        {errorMessage}
+      </div>
+    );
+  }
+
+  let resetConfirmUi = null;
+  if (confirmingReset) {
+    resetConfirmUi = (
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
+        <span className="text-bs-secondary">保存されたセッション履歴がすべて削除されます</span>
+        <button
+          type="button"
+          className="rounded border border-red-400 px-2 py-0.5 text-xs text-red-700"
+          data-testid="sessions-reset-confirm"
+          disabled={resetting || deleteActionsDisabled}
+          onClick={handleConfirmReset}
+        >
+          削除する
+        </button>
+        <button
+          type="button"
+          className="rounded border border-bs-secondary px-2 py-0.5 text-xs"
+          data-testid="sessions-reset-cancel"
+          disabled={resetting || deleteActionsDisabled}
+          onClick={() => {
+            setConfirmingReset(false);
+          }}
+        >
+          キャンセル
+        </button>
+      </div>
+    );
+  }
+
+  let listBody = null;
+  if (loading) {
+    listBody = (
+      <p className="text-bs-secondary" data-testid="session-list-loading">
+        読み込み中…
+      </p>
+    );
+  } else if (!databaseAvailable) {
+    listBody = (
+      <p className="text-bs-secondary" data-testid="session-database-unavailable">
+        セッション永続化が利用できません（OPFS 非対応、またはデータベース初期化に失敗しています）
+      </p>
+    );
+  } else {
+    listBody = (
+      <SessionList
+        sessions={sessions}
+        currentSessionDbId={currentSessionDbId}
+        selectedSessionDbId={searchParams.sessionDbId}
+        onSelect={(sessionDbId) => {
+          applySearchParams({ ...searchParams, sessionDbId });
+        }}
+        onRequestDelete={(sessionDbId) => {
+          setConfirmingReset(false);
+          setConfirmingSessionDbId(sessionDbId);
+        }}
+        onConfirmDelete={handleConfirmDelete}
+        onCancelDelete={() => {
+          setConfirmingSessionDbId(null);
+        }}
+        confirmingSessionDbId={confirmingSessionDbId}
+        deletingSessionDbId={deletingSessionDbId}
+        deleteActionsDisabled={deleteActionsDisabled}
+      />
+    );
+  }
+
+  let resetButton = null;
+  if (showDeleteUi) {
+    resetButton = (
+      <button
+        type="button"
+        className="rounded border border-bs-secondary px-2 py-0.5 text-sm"
+        data-testid="sessions-reset-database"
+        disabled={resetDisabled}
+        onClick={() => {
+          setConfirmingSessionDbId(null);
+          setConfirmingReset(true);
+        }}
+      >
+        履歴を削除
+      </button>
+    );
+  }
+
+  let detailKey = "none";
+  if (searchParams.sessionDbId !== undefined) {
+    detailKey = String(searchParams.sessionDbId);
+  }
 
   return (
     <main className="mx-auto max-w-6xl px-4 py-4" data-testid="sessions-page">
       <h1 className="mb-3 text-2xl font-semibold">Sessions</h1>
       <PrivacyNotice />
-
-      {errorMessage !== null ? (
-        <div
-          className="mb-4 rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800"
-          data-testid="sessions-page-error"
-          role="alert"
-        >
-          セッション一覧の読み取りに失敗しました: {errorMessage}
-        </div>
-      ) : null}
-
+      {errorAlert}
       <SessionFilter value={searchParams} onChange={applySearchParams} />
-
       <section className="mb-6">
-        <h2 className="mb-2 text-lg font-semibold">一覧</h2>
-        {loading ? (
-          <p className="text-bs-secondary" data-testid="session-list-loading">
-            読み込み中…
-          </p>
-        ) : null}
-        {!loading && !databaseAvailable ? (
-          <p className="text-bs-secondary" data-testid="session-database-unavailable">
-            セッション永続化が利用できません（OPFS
-            非対応、またはデータベース初期化に失敗しています）
-          </p>
-        ) : null}
-        {!loading && databaseAvailable ? (
-          <SessionList
-            sessions={sessions}
-            currentSessionDbId={currentSessionDbId}
-            selectedSessionDbId={searchParams.sessionDbId}
-            onSelect={handleSelect}
-          />
-        ) : null}
+        <div className="mb-2 flex flex-wrap items-center gap-3">
+          <h2 className="text-lg font-semibold">一覧</h2>
+          {resetButton}
+        </div>
+        {resetConfirmUi}
+        {listBody}
       </section>
-
       <section>
-        <SessionDetail
-          key={searchParams.sessionDbId === undefined ? "none" : String(searchParams.sessionDbId)}
-          sessionDbId={searchParams.sessionDbId}
-        />
+        <SessionDetail key={detailKey} sessionDbId={searchParams.sessionDbId} />
       </section>
     </main>
   );

--- a/src/sessionDatabase.ts
+++ b/src/sessionDatabase.ts
@@ -144,6 +144,8 @@ let checkpointTimerId: ReturnType<typeof setInterval> | null = null;
 let lastAlertMessage: string | null = null;
 let lastAlertAt = 0;
 let initStarted = false;
+// 履歴削除（OPFS 再作成）の実行中。この間 insertSession は DB へ書かない
+let resetInProgress = false;
 // AsyncDuckDBConnection は同一接続への並行 query を想定しないため、書き込みを直列化する
 let writeChain: Promise<void> = Promise.resolve();
 
@@ -579,7 +581,7 @@ export async function insertSession(
   // 初期化完了前の Connect で no-op にならないよう、書き込み前に初期化を待つ
   await whenReady();
   return enqueueWrite(async () => {
-    if (duckdbConnection === null) {
+    if (duckdbConnection === null || resetInProgress) {
       warnUnavailable("insertSession");
       return null;
     }
@@ -1036,12 +1038,12 @@ async function flushOneStatsBuffer(targetId: number, buffer: StatsBufferState): 
   buffer.rows = [];
   buffer.firstEnqueueAt = null;
   await enqueueWrite(async () => {
+    // 削除済み session の抽出済みバッチは INSERT しない（孤児行を残さない）
+    if (!statsBuffers.has(targetId)) {
+      return;
+    }
     if (duckdbConnection === null) {
       warnUnavailable("flushStatsBuffer");
-      // close 済みで map から外れている場合は orphan 復元しない
-      if (!statsBuffers.has(targetId)) {
-        return;
-      }
       buffer.rows = [...rows, ...buffer.rows];
       scheduleStatsFlush(targetId);
       return;
@@ -1160,6 +1162,53 @@ export async function querySessionDatabaseForE2e(
 // E2E ヘルパーから OPFS 上の DB ファイルを削除するために export する
 export async function deleteSessionDatabaseFiles(): Promise<void> {
   await deleteOpfsDatabaseFile();
+}
+
+// 当該 session_db_id の webrtc_stats / connections / sessions を削除する
+export async function deleteSession(sessionDbId: number): Promise<void> {
+  await whenReady();
+  if (sessionDbId === getCurrentSessionDbId()) {
+    throw new Error(`Cannot delete session: sessionDbId ${sessionDbId} is the current session`);
+  }
+  await enqueueWrite(async () => {
+    if (duckdbConnection === null) {
+      throw new Error("Cannot delete session: session database is unavailable");
+    }
+    clearStatsBuffers(sessionDbId);
+    const deleteStats = await duckdbConnection.prepare(
+      "DELETE FROM webrtc_stats WHERE session_db_id = ?",
+    );
+    await deleteStats.query(sessionDbId);
+    await deleteStats.close();
+    const deleteConnections = await duckdbConnection.prepare(
+      "DELETE FROM connections WHERE session_db_id = ?",
+    );
+    await deleteConnections.query(sessionDbId);
+    await deleteConnections.close();
+    const deleteSessions = await duckdbConnection.prepare("DELETE FROM sessions WHERE id = ?");
+    await deleteSessions.query(sessionDbId);
+    await deleteSessions.close();
+    await runCheckpointUnlocked();
+  });
+}
+
+// OPFS 上の DB を削除して空のデータベースを開き直す
+export async function resetSessionDatabase(): Promise<void> {
+  if (getCurrentSessionDbId() !== null) {
+    throw new Error("Cannot reset session database: a session is in progress");
+  }
+  resetInProgress = true;
+  try {
+    await close();
+    await deleteOpfsDatabaseFile();
+    await createSessionDatabase();
+    await whenReady();
+    if (!isSessionDatabaseAvailable()) {
+      throw new Error("Cannot reset session database: failed to reopen empty database");
+    }
+  } finally {
+    resetInProgress = false;
+  }
 }
 
 // --- 読み取り API（書き込みと同じ直列化キュー経由） ---

--- a/tests/helpers/sessionDatabase.ts
+++ b/tests/helpers/sessionDatabase.ts
@@ -218,3 +218,39 @@ export async function waitForWebrtcStats(
       `sessionDbId=${String(options.sessionDbId)})`,
   );
 }
+
+// アプリ側 deleteSession を呼ぶ（UI ではなく API 直叩きの DB 層テスト用）
+export async function callDeleteSession(page: Page, sessionDbId: number): Promise<void> {
+  await page.evaluate(
+    async ({ moduleUrl, id }) => {
+      const loaded: unknown = await import(/* @vite-ignore */ moduleUrl);
+      const mod = loaded as {
+        deleteSession: (sessionDbId: number) => Promise<void>;
+      };
+      await mod.deleteSession(id);
+    },
+    { moduleUrl: SESSION_DATABASE_MODULE_URL, id: sessionDbId },
+  );
+}
+
+// アプリ側 resetSessionDatabase を呼ぶ
+export async function callResetSessionDatabase(page: Page): Promise<void> {
+  await page.evaluate(async (moduleUrl) => {
+    const loaded: unknown = await import(/* @vite-ignore */ moduleUrl);
+    const mod = loaded as {
+      resetSessionDatabase: () => Promise<void>;
+    };
+    await mod.resetSessionDatabase();
+  }, SESSION_DATABASE_MODULE_URL);
+}
+
+// アプリ側 getCurrentSessionDbId を読む
+export async function readCurrentSessionDbId(page: Page): Promise<number | null> {
+  return page.evaluate(async (moduleUrl) => {
+    const loaded: unknown = await import(/* @vite-ignore */ moduleUrl);
+    const mod = loaded as {
+      getCurrentSessionDbId: () => number | null;
+    };
+    return mod.getCurrentSessionDbId();
+  }, SESSION_DATABASE_MODULE_URL);
+}

--- a/tests/session-database.test.ts
+++ b/tests/session-database.test.ts
@@ -3,9 +3,14 @@ import { expect, test } from "@playwright/test";
 import { requireSoraConnectionEnv } from "./helpers/env.ts";
 import {
   awaitSessionDatabaseReady,
+  callDeleteSession,
+  callResetSessionDatabase,
   cleanupSessionDatabase,
+  listConnectionRows,
   listSessionRows,
+  listWebrtcStatsRows,
   waitForEndedAt,
+  waitForWebrtcStats,
 } from "./helpers/sessionDatabase.ts";
 import { DevtoolsPage } from "./pages/DevtoolsPage.ts";
 
@@ -194,5 +199,196 @@ test.describe("session database persistence", () => {
     const { session: latest } = await waitForEndedAt(page, { connectionId });
     expect(latest.channel_id).toBe(channelId);
     expect(latest.ended_at).toBeTruthy();
+  });
+
+  test("deleteSession は関連 connections / webrtc_stats を消し current は拒否する", async ({
+    page,
+  }) => {
+    const env = requireSoraConnectionEnv();
+    const channelId = `${env.channelIdPrefix}session-db-delete`;
+
+    const first = await (async () => {
+      const devtools = new DevtoolsPage(page);
+      await devtools.navigate({
+        role: "sendrecv",
+        channelId,
+        signalingUrlCandidates: [env.signalingUrl],
+        accessToken: env.accessToken,
+        videoCodecType: "VP9",
+      });
+      await awaitSessionDatabaseReady(page);
+      await devtools.connect();
+      await devtools.waitForConnection();
+      const connectionId = await devtools.getConnectionId();
+      expect(connectionId).toBeTruthy();
+      if (!connectionId) {
+        throw new Error("expected non-empty connection ID");
+      }
+      await page.waitForTimeout(1500);
+      await devtools.disconnect();
+      const ended = await waitForEndedAt(page, { connectionId });
+      await waitForWebrtcStats(page, {
+        connectionId,
+        sessionDbId: ended.session.id,
+        channelId,
+        minCount: 1,
+      });
+      return ended.session.id;
+    })();
+
+    const second = await (async () => {
+      const devtools = new DevtoolsPage(page);
+      await devtools.navigate({
+        role: "sendrecv",
+        channelId,
+        signalingUrlCandidates: [env.signalingUrl],
+        accessToken: env.accessToken,
+        videoCodecType: "VP9",
+      });
+      await awaitSessionDatabaseReady(page);
+      await devtools.connect();
+      await devtools.waitForConnection();
+      const connectionId = await devtools.getConnectionId();
+      expect(connectionId).toBeTruthy();
+      if (!connectionId) {
+        throw new Error("expected non-empty connection ID");
+      }
+      await page.waitForTimeout(1500);
+      await devtools.disconnect();
+      const ended = await waitForEndedAt(page, { connectionId });
+      await waitForWebrtcStats(page, {
+        connectionId,
+        sessionDbId: ended.session.id,
+        channelId,
+        minCount: 1,
+      });
+      return ended.session.id;
+    })();
+
+    expect(second).not.toBe(first);
+
+    await callDeleteSession(page, first);
+
+    const sessions = await listSessionRows(page);
+    expect(sessions.find((row) => row.id === first)).toBeUndefined();
+    expect(sessions.find((row) => row.id === second)).toBeTruthy();
+
+    const connections = await listConnectionRows(page);
+    expect(connections.filter((row) => row.session_db_id === first)).toHaveLength(0);
+
+    const stats = await listWebrtcStatsRows(page);
+    expect(stats.filter((row) => row.session_db_id === first)).toHaveLength(0);
+
+    // 接続中の current 拒否
+    const live = new DevtoolsPage(page);
+    await live.navigate({
+      role: "sendrecv",
+      channelId: `${channelId}-live`,
+      signalingUrlCandidates: [env.signalingUrl],
+      accessToken: env.accessToken,
+      videoCodecType: "VP9",
+    });
+    await awaitSessionDatabaseReady(page);
+    await live.connect();
+    await live.waitForConnection();
+    const liveConnectionId = await live.getConnectionId();
+    expect(liveConnectionId).toBeTruthy();
+
+    const currentId = await page.evaluate(async (moduleUrl) => {
+      const loaded: unknown = await import(/* @vite-ignore */ moduleUrl);
+      const mod = loaded as { getCurrentSessionDbId: () => number | null };
+      return mod.getCurrentSessionDbId();
+    }, "/src/sessionDatabase.ts");
+    expect(currentId).not.toBeNull();
+    if (currentId === null) {
+      throw new Error("expected current session id");
+    }
+
+    let rejected = false;
+    let deleteMessage = "";
+    try {
+      await callDeleteSession(page, currentId);
+    } catch (error) {
+      rejected = true;
+      if (error instanceof Error) {
+        deleteMessage = error.message;
+      }
+    }
+    expect(rejected).toBe(true);
+    expect(deleteMessage).toContain(
+      `Cannot delete session: sessionDbId ${currentId} is the current session`,
+    );
+
+    let resetRejected = false;
+    let resetMessage = "";
+    try {
+      await callResetSessionDatabase(page);
+    } catch (error) {
+      resetRejected = true;
+      if (error instanceof Error) {
+        resetMessage = error.message;
+      }
+    }
+    expect(resetRejected).toBe(true);
+    expect(resetMessage).toContain("Cannot reset session database: a session is in progress");
+
+    await live.disconnect();
+  });
+
+  test("resetSessionDatabase 後は空になり再接続で記録できる", async ({ page }) => {
+    const env = requireSoraConnectionEnv();
+    const channelId = `${env.channelIdPrefix}session-db-reset`;
+
+    const devtools = new DevtoolsPage(page);
+    await devtools.navigate({
+      role: "sendrecv",
+      channelId,
+      signalingUrlCandidates: [env.signalingUrl],
+      accessToken: env.accessToken,
+      videoCodecType: "VP9",
+    });
+    await awaitSessionDatabaseReady(page);
+    await devtools.connect();
+    await devtools.waitForConnection();
+    const connectionId = await devtools.getConnectionId();
+    expect(connectionId).toBeTruthy();
+    if (!connectionId) {
+      throw new Error("expected non-empty connection ID");
+    }
+    await page.waitForTimeout(1500);
+    await devtools.disconnect();
+    await waitForEndedAt(page, { connectionId });
+
+    const before = await listSessionRows(page);
+    expect(before.length).toBeGreaterThanOrEqual(1);
+
+    await callResetSessionDatabase(page);
+
+    const afterResetSessions = await listSessionRows(page);
+    expect(afterResetSessions).toHaveLength(0);
+    const afterResetConnections = await listConnectionRows(page);
+    expect(afterResetConnections).toHaveLength(0);
+    const afterResetStats = await listWebrtcStatsRows(page);
+    expect(afterResetStats).toHaveLength(0);
+
+    await devtools.navigate({
+      role: "sendrecv",
+      channelId: `${channelId}-again`,
+      signalingUrlCandidates: [env.signalingUrl],
+      accessToken: env.accessToken,
+      videoCodecType: "VP9",
+    });
+    await awaitSessionDatabaseReady(page);
+    await devtools.connect();
+    await devtools.waitForConnection();
+    const againConnectionId = await devtools.getConnectionId();
+    expect(againConnectionId).toBeTruthy();
+    if (!againConnectionId) {
+      throw new Error("expected non-empty connection ID");
+    }
+    await page.waitForTimeout(1000);
+    await devtools.disconnect();
+    const again = await waitForEndedAt(page, { connectionId: againConnectionId });
+    expect(again.session.id).toBeTruthy();
   });
 });

--- a/tests/sessions-page.test.ts
+++ b/tests/sessions-page.test.ts
@@ -110,9 +110,9 @@ test.describe("sessions page UI", () => {
     expect(hasAggregateValue || hasRawPanel).toBe(true);
   });
 
-  test("行削除と履歴削除が動作し確認キャンセルでは消えない", async ({ page }) => {
+  test("行削除の確認キャンセルでは消えず、確定でカスケード削除される", async ({ page }) => {
     const env = requireSoraConnectionEnv();
-    const channelId = `${env.channelIdPrefix}sessions-page-delete`;
+    const channelId = `${env.channelIdPrefix}sessions-page-row-delete`;
 
     const first = await connectAndPersist(page, channelId);
     const second = await connectAndPersist(page, channelId);
@@ -147,11 +147,22 @@ test.describe("sessions page UI", () => {
     await expect(page.getByTestId(`session-row-${second.sessionDbId}`)).toBeVisible({
       timeout: 10_000,
     });
+  });
+
+  test("履歴削除の確認キャンセルでは消えず、確定後は再記録できる", async ({ page }) => {
+    const env = requireSoraConnectionEnv();
+    const channelId = `${env.channelIdPrefix}sessions-page-reset`;
+
+    const persisted = await connectAndPersist(page, channelId);
+
+    await page.goto(`${BASE_URL}/sessions`);
+    await page.getByTestId("session-list").waitFor({ timeout: 10_000 });
+    await page.getByTestId(`session-row-${persisted.sessionDbId}`).waitFor({ timeout: 10_000 });
 
     // 履歴削除のキャンセル
     await page.getByTestId("sessions-reset-database").click();
     await page.getByTestId("sessions-reset-cancel").click();
-    await expect(page.getByTestId(`session-row-${second.sessionDbId}`)).toBeVisible();
+    await expect(page.getByTestId(`session-row-${persisted.sessionDbId}`)).toBeVisible();
 
     // 履歴削除
     await page.getByTestId("sessions-reset-database").click();

--- a/tests/sessions-page.test.ts
+++ b/tests/sessions-page.test.ts
@@ -5,6 +5,8 @@ import { requireSoraConnectionEnv } from "./helpers/env.ts";
 import {
   awaitSessionDatabaseReady,
   cleanupSessionDatabase,
+  listConnectionRows,
+  listWebrtcStatsRows,
   waitForEndedAt,
   waitForWebrtcStats,
 } from "./helpers/sessionDatabase.ts";
@@ -106,5 +108,99 @@ test.describe("sessions page UI", () => {
     const hasAggregateValue = aggregatesText !== null && /\d/u.test(aggregatesText);
     const hasRawPanel = await rawPanel.isVisible().catch(() => false);
     expect(hasAggregateValue || hasRawPanel).toBe(true);
+  });
+
+  test("行削除と履歴削除が動作し確認キャンセルでは消えない", async ({ page }) => {
+    const env = requireSoraConnectionEnv();
+    const channelId = `${env.channelIdPrefix}sessions-page-delete`;
+
+    const first = await connectAndPersist(page, channelId);
+    const second = await connectAndPersist(page, channelId);
+
+    await page.goto(`${BASE_URL}/sessions`);
+    await page.getByTestId("session-list").waitFor({ timeout: 10_000 });
+    await page.getByTestId(`session-row-${first.sessionDbId}`).waitFor({ timeout: 10_000 });
+    await page.getByTestId(`session-row-${second.sessionDbId}`).waitFor({ timeout: 10_000 });
+
+    // キャンセルでは消えない
+    await page.getByTestId(`session-delete-${first.sessionDbId}`).click();
+    await page.getByTestId(`session-delete-cancel-${first.sessionDbId}`).click();
+    await expect(page.getByTestId(`session-row-${first.sessionDbId}`)).toBeVisible();
+
+    // 行削除
+    await page.getByTestId(`session-delete-${first.sessionDbId}`).click();
+    await page.getByTestId(`session-delete-confirm-${first.sessionDbId}`).click();
+    await expect(page.getByTestId(`session-row-${first.sessionDbId}`)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId(`session-row-${second.sessionDbId}`)).toBeVisible();
+
+    // カスケード確認はシナリオ末尾で helpers を使う
+    const connections = await listConnectionRows(page);
+    expect(connections.filter((row) => row.session_db_id === first.sessionDbId)).toHaveLength(0);
+    const stats = await listWebrtcStatsRows(page);
+    expect(stats.filter((row) => row.session_db_id === first.sessionDbId)).toHaveLength(0);
+
+    // helpers が close/reopen したあと DOM を再取得する
+    await page.goto(`${BASE_URL}/sessions`);
+    await page.getByTestId("session-list").waitFor({ timeout: 10_000 });
+    await expect(page.getByTestId(`session-row-${second.sessionDbId}`)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // 履歴削除のキャンセル
+    await page.getByTestId("sessions-reset-database").click();
+    await page.getByTestId("sessions-reset-cancel").click();
+    await expect(page.getByTestId(`session-row-${second.sessionDbId}`)).toBeVisible();
+
+    // 履歴削除
+    await page.getByTestId("sessions-reset-database").click();
+    await page.getByTestId("sessions-reset-confirm").click();
+    await page.getByTestId("session-list-empty").waitFor({ timeout: 10_000 });
+
+    // 再接続で再記録
+    const again = await connectAndPersist(page, `${channelId}-again`);
+    await page.goto(`${BASE_URL}/sessions`);
+    await page.getByTestId(`session-row-${again.sessionDbId}`).waitFor({ timeout: 10_000 });
+  });
+
+  test("接続中は履歴削除が disabled で当該行の削除ボタンが無い", async ({ page }) => {
+    const env = requireSoraConnectionEnv();
+    const channelId = `${env.channelIdPrefix}sessions-page-live-delete`;
+
+    const past = await connectAndPersist(page, channelId);
+
+    const live = new DevtoolsPage(page);
+    await live.navigate({
+      role: "sendrecv",
+      channelId: `${channelId}-live`,
+      signalingUrlCandidates: [env.signalingUrl],
+      accessToken: env.accessToken,
+      videoCodecType: "VP9",
+    });
+    await awaitSessionDatabaseReady(page);
+    await live.connect();
+    await live.waitForConnection();
+
+    const currentId = await page.evaluate(async (moduleUrl) => {
+      const loaded: unknown = await import(/* @vite-ignore */ moduleUrl);
+      const mod = loaded as { getCurrentSessionDbId: () => number | null };
+      return mod.getCurrentSessionDbId();
+    }, "/src/sessionDatabase.ts");
+    expect(currentId).not.toBeNull();
+
+    // フルリロードではなく SPA 遷移で接続状態を維持する
+    await page.getByRole("button", { name: "Sessions" }).click();
+    await page.getByRole("heading", { name: "Sessions", exact: true }).waitFor({ timeout: 10_000 });
+    await page.getByTestId("session-list").waitFor({ timeout: 10_000 });
+    await expect(page.getByTestId("sessions-reset-database")).toBeDisabled();
+    if (currentId !== null) {
+      await expect(page.getByTestId(`session-delete-${currentId}`)).toHaveCount(0);
+    }
+    await expect(page.getByTestId(`session-delete-${past.sessionDbId}`)).toBeVisible();
+
+    await page.getByRole("link", { name: "Sora DevTools" }).click();
+    await page.waitForURL((url) => url.pathname === "/", { timeout: 5000 });
+    await live.disconnect();
   });
 });


### PR DESCRIPTION
## 概要

DuckDB-Wasm + OPFS に溜まった過去セッションを、`/sessions` 一覧から行単位・全履歴で削除できるようにする。

## 変更内容

- `deleteSession` / `resetSessionDatabase` を追加し、削除済み id への孤児 INSERT を防ぐ
- 一覧に行削除・履歴削除の 2 段確認 UI を追加する（`no-alert`）
- Playwright E2E でカスケード削除・拒否・再記録・接続中 disabled を検証する

## 完了条件

- [x] 過去セッションを行単位で削除でき、紐づく connections / webrtc_stats も残らない
- [x] 履歴削除後は一覧が空になり、その後の接続で再び記録できる
- [x] 進行中セッションは行削除できない（ボタン非表示、API は throw）
- [x] 接続試行中は履歴削除が disabled / API は current ありで throw
- [x] `window.confirm` / `alert` を使っていない
- [x] `vp build` / `vp test run` / 関連 E2E / `vp check` が成功する
- [x] CHANGES.md に `[ADD]` を記載する

## 関連 issue

- issues/closed/0073-add-sessions-delete-ui.md